### PR TITLE
Update TissUUmap service

### DIFF
--- a/data/services.json
+++ b/data/services.json
@@ -302,7 +302,8 @@
     "thumbnail": "/img/service_thumbnails/tissuumaps.jpg",
     "maintained_by": "TissUUmaps",
     "maintained_by_url": "https://tissuumaps.github.io/about_us/",
-    "support_email": "carolina.wahlby@it.uu.se"
+    "support_email": "biif@scilifelab.se",
+    "support_github": "https://github.com/TissUUmaps/TissUUmaps"
   },
   {
     "target": [


### PR DESCRIPTION
Change the Support link to the github page https://github.com/TissUUmaps/TissUUmaps and use the biif email (biif@scilifelab.se) instead of Carolina's email for a contact for support