### PR TITLE
added status link to check service status

### DIFF
--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -16,7 +16,7 @@ menu:
 
 The SciLifeLab Data Platform includes a technical environment for hosting tools and databases that can be deployed or accessed via the web. The hosting resources are [managed by the SciLifeLab Data Centre](/about/). Individual researchers, research groups, and research organisations are enouraged to [learn more and apply for hosting](./hosting/).
 
-Below, you will find information about [resources related to hosting](#for-researchers) and [for data-producing facilities](#for-facilities) that are either hosted or linked via the SciLifeLab Data Platform.
+Below, you will find information about [resources related to hosting](#for-researchers) and [for data-producing facilities](#for-facilities) that are either hosted or linked via the SciLifeLab Data Platform. Status and uptime of the services maintained by Scilifelab Data Centre can be found [here](https://status.dc.scilifelab.se/).
 
 <ul>
   <li><a href="#for-researchers">Services for researchers <i class="bi bi-arrow-down-square-fill"></i></a></li>

--- a/data/services.json
+++ b/data/services.json
@@ -68,7 +68,8 @@
     "maintained_by": "SciLifeLab Data Centre",
     "maintained_by_url": "https://scilifelab.se/data",
     "support_email": "datacentre@scilifelab.se",
-    "support_github": "https://github.com/ScilifelabDataCentre/covid-portal/tree/develop"
+    "support_github": "https://github.com/ScilifelabDataCentre/covid-portal/tree/develop",
+    "support_status": "https://status.dc.scilifelab.se/793602036"
   },
   {
     "target": [
@@ -95,7 +96,8 @@
     "maintained_by": "NBIS, SciLifeLab Data Centre",
     "support_email": "data-management@scilifelab.se",
     "support_website": "https://data-guidelines.scilifelab.se/contact/",
-    "support_github": "https://github.com/ScilifelabDataCentre/RDM-guidelines"
+    "support_github": "https://github.com/ScilifelabDataCentre/RDM-guidelines",
+    "support_status": "https://status.dc.scilifelab.se/793602117"
   },
   {
     "target": [
@@ -203,7 +205,8 @@
     "url": "https://delivery.scilifelab.se/",
     "maintained_by": "SciLifeLab Data Centre",
     "maintained_by_url": "https://scilifelab.se/data",
-    "support_email": "datacentre@scilifelab.se"
+    "support_email": "datacentre@scilifelab.se",
+    "support_status": "https://status.dc.scilifelab.se/793448467"
   },
   {
     "target": [
@@ -224,7 +227,8 @@
     "url": "https://orderportal.scilifelab.se/",
     "maintained_by": "SciLifeLab Data Centre",
     "maintained_by_url": "https://scilifelab.se/data",
-    "support_email": "datacentre@scilifelab.se"
+    "support_email": "datacentre@scilifelab.se",
+    "support_status": "https://status.dc.scilifelab.se/793602084"
   },
   {
     "target": [
@@ -245,7 +249,8 @@
     "url": "https://anubis.scilifelab.se/",
     "maintained_by": "SciLifeLab Data Centre",
     "maintained_by_url": "https://scilifelab.se/data",
-    "support_email": "datacentre@scilifelab.se"
+    "support_email": "datacentre@scilifelab.se",
+    "support_status": "https://status.dc.scilifelab.se/793602009"
   },
   {
     "target": [
@@ -303,7 +308,8 @@
     "maintained_by": "TissUUmaps",
     "maintained_by_url": "https://tissuumaps.github.io/about_us/",
     "support_email": "biif@scilifelab.se",
-    "support_github": "https://github.com/TissUUmaps/TissUUmaps"
+    "support_github": "https://github.com/TissUUmaps/TissUUmaps",
+    "support_status": "https://status.dc.scilifelab.se/793601986"
   },
   {
     "target": [
@@ -336,7 +342,8 @@
     "thumbnail": "/img/service_thumbnails/aida.jpg",
     "maintained_by": "AIDA Data Hub",
     "maintained_by_url": "https://datahub.aida.scilifelab.se/about/",
-    "support_email": "aida-data-director@medtech4health.se"
+    "support_email": "aida-data-director@medtech4health.se",
+    "support_status": "https://status.dc.scilifelab.se/793602004"
   },
   {
     "target": [
@@ -388,7 +395,8 @@
     "thumbnail": "/img/service_thumbnails/dsw.jpg",
     "url": "https://dsw.scilifelab.se/",
     "maintained_by": "NBIS, SciLifeLab Data Centre",
-    "support_email": "datacentre@scilifelab.se"
+    "support_email": "datacentre@scilifelab.se",
+    "support_status": "https://status.dc.scilifelab.se/793602047"
   },
   {
     "target": [

--- a/layouts/services/list.html
+++ b/layouts/services/list.html
@@ -71,6 +71,7 @@
         {{ with .support_email }}<a href="mailto:{{ . }}"><i class="bi bi-envelope-fill"></i></a> {{ end }}
         {{ with .support_website }}<a href="{{ . }}"><i class="bi bi-globe"></i></a> {{ end }}
         {{ with .support_github }}<a href="{{ . }}"><i class="bi bi-github"></i></a> {{ end }}
+        {{ with .support_status }}<a href="{{ . }}"><i class="bi bi-hdd-rack"></i></a> {{ end }}
       </div>
       {{ end }}
     </div>


### PR DESCRIPTION
Chores:
- Jira issue: FREYA-280
- added service status link in description
- added service status icon with link in each service card