### PR TITLE
Show funding deadline time when available

### DIFF
--- a/layouts/funding_calls/list.html
+++ b/layouts/funding_calls/list.html
@@ -135,6 +135,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         var blockHTML = `<div class="row g-2 mt-3 mb-4">`;
         
           dataList.forEach((item, ind) => {
+            var long_date = new Date(item.deadline).toLocaleString('en-US', {'month': 'short', day:'numeric', year: 'numeric'});
             blockHTML += `
             <div class="col-md-6 col-lg-4">
               <div class="card-box">`;
@@ -148,14 +149,15 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     <div class="px-2 fs-3 mx-auto">${ new Date(item.deadline).getDate() }</div>
                     <div class="pb-1 px-2 mx-auto">${ new Date(item.deadline).toLocaleString('default', {'month': 'long'}) }</div>
                   </div>
+                </div>
+                <div>
+                  <b>Deadline:</b> ${item.deadline_time ? long_date + " - " + item.deadline_time : long_date}
                 </div>`;
 
                 if(item.funder) {
                   blockHTML += `
-                  <div class="row">
-                    <div class="col">
-                      <b>Funder:</b> ${item.funder}
-                    </div>
+                  <div>
+                    <b>Funder:</b> ${item.funder}
                   </div>`; 
                 }
 
@@ -177,7 +179,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                           <div class="modal-body">
                             <div class="row mt-1">
                               <div class="col">
-                                <b>Application deadline:</b> ${ new Date(item.deadline).toLocaleString('en-US', {'month': 'short', day:'numeric', year: 'numeric'}) }
+                                <b>Application deadline:</b> ${item.deadline_time ? long_date + " - " + item.deadline_time : long_date}
                               </div>
                             </div>`;
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <header class="header" style="background-image: url('/img/illustrations/circle_zoomed.png'); color: white; ">
     <div class="container">
       <div class="py-2 my-1">
-        <h2><a class="banner-title-link" href="/news/#20240418">Request for services related to cell- and molecular biology now open!</a></h2>
+        <h2><a class="banner-title-link" href="/news/#20240418">Welcome to the SciLifeLab Data Platform</a></h2>
       </div>
     </div>
   </header>


### PR DESCRIPTION
When a `deadline_time` is added to a funding call, it will also be displayed with the date. For example, it would look like

<img width="275" alt="Screenshot 2024-05-30 at 12 38 52" src="https://github.com/ScilifelabDataCentre/data.scilifelab.se/assets/5311007/21c64df2-8686-476a-8dc6-3a0f75856911">
