### PR TITLE
Version bump: Git action 'checkout'

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -37,7 +37,7 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # only needed when publishing to Github (ghcr.io)
       - name: Log in to Github Container Repository
         uses: docker/login-action@v2

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/pa11y_test.yaml
+++ b/.github/workflows/pa11y_test.yaml
@@ -18,12 +18,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
-            - name: Set up Node.js 18.x
+            - name: Set up Node.js 22.x
               uses: actions/setup-node@v4
               with:
-                node-version: 18.x
+                node-version: 22.x
             
             - name: Install Pa11ly CI
               run: npm install -g pa11y-ci

--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.9.2

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure lowercase name
         run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV


### PR DESCRIPTION
Currently we are using `checkout` version 3, it uses an older version of `node 16.x`
There is new newer version 4 for `checkout`, which uses `node 20.x`