### PR TITLE
Allow frame for same origin

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -16,7 +16,7 @@ RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER
 # Serve the generated html using nginx
 FROM nginxinc/nginx-unprivileged:alpine
 RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf && \
-    sed -i '4 a\    add_header X-Frame-Options DENY always;' /etc/nginx/conf.d/default.conf && \
+    sed -i '4 a\    add_header X-Frame-Options SAMEORIGIN always;' /etc/nginx/conf.d/default.conf && \
     sed -i 's/#error_page  404/error_page  404/' /etc/nginx/conf.d/default.conf
 COPY --from=build /target /usr/share/nginx/html
 


### PR DESCRIPTION
We are trying to show a `pdf` file in an embed frame, so change allow to be frame in the `SAMEORIGIN` i.e. our own site