### PR TITLE
Remove padding on result text highlight

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -377,3 +377,7 @@ h5 a:hover {
   transition: 0.1s;
   text-decoration: none;
 }
+
+#search-results mark {
+  padding: 0;
+}


### PR DESCRIPTION
This will fix the extra white space created in the search results while highlighting the typed text in the title.