### PR TITLE
Updates old link of KTH storage with new one

### DIFF
--- a/content/resources/storage.md
+++ b/content/resources/storage.md
@@ -22,7 +22,7 @@ Most of the resources described on this page are national and do not require tha
 
 - [Karolinska Institutet (KI)](https://staff.ki.se/guidelines-for-research-documentation-and-data-management)
 
-- [KTH Royal Institute of Technology (KTH)](https://www.kth.se/en/biblioteket/publicera-analysera/hantera-forskningsdata/lagring-av-forskningsdata-och-langsiktigt-bevarande-1.861129)
+- [KTH Royal Institute of Technology (KTH)](https://www.kth.se/en/biblioteket/publicera-analysera/hantera-forskningsdata/samla-lagra-och-analysera-1.1380800)
 
 - [Lund University (LU)](https://www.staff.lu.se/research-and-education/research-support/support-research-process/research-data-management)
 


### PR DESCRIPTION
This pull request includes a small update to the `content/resources/storage.md` file. The change updates the URL for the KTH Royal Institute of Technology (KTH) resource link to a new address.

Closes: [FREYA-1249](https://scilifelab.atlassian.net/browse/FREYA-1249)