### PR TITLE
Adds Schema.org Structured data for improved SEO

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -98,4 +98,8 @@
   </script>
   {{ end }}
 
+  {{ if strings.HasPrefix hugo.Environment "production" }}  
+    <!-- Schema.org data -->
+    {{ partial "schema.html" . }}
+  {{ end }}
 </head>

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,0 +1,270 @@
+{{/*
+    schema.html
+    This is the Schema partial for data.scilifelab.se
+    It generates relevant schema (WebSite, DataCatalog, or Dataset) and keywords
+    depending on whether the page is highlights/services/resources (single or listing).
+  */}}
+  
+  {{/* Default values */}}
+  {{ $type := "WebPage" }}
+  {{ $name := .Site.Title }}
+  {{ $description := (or .Params.description .Params.summary .Site.Params.description) }}
+  {{ $image := index .Site.Params.Images 0 | absURL }}
+  
+  {{ $currentPage := path.Split (path.Clean .RelPermalink) }}
+  
+  {{/* Determine page type */}}
+  {{ $isHomePage := .IsHome }}
+  {{ $isSingleHighlightPage := and (eq $currentPage.Dir "/highlights/") ($currentPage.File) }}
+  {{ $isHighlightsPage := and (strings.HasPrefix .RelPermalink "/highlights") (not $isSingleHighlightPage) }}
+  {{ $isSingleResourcePage := and (eq $currentPage.Dir "/resources/") ($currentPage.File) }}
+  {{ $isResourcesPage := and (strings.HasPrefix .RelPermalink "/resources") (not $isSingleResourcePage) }}
+  {{ $isSingleServicePage := and (eq $currentPage.Dir "/services/") ($currentPage.File) }}
+  {{ $isServicesPage := and (strings.HasPrefix .RelPermalink "/services") (not $isSingleServicePage) }}
+  
+  {{/* Overwrite $type based on page */}}
+  {{ if $isHomePage }}
+    {{ $type = "WebSite" }}
+  {{ else if $isSingleHighlightPage }}
+    {{ $type = "Dataset" }}
+  {{ else if $isHighlightsPage }}
+    {{ $type = "DataCatalog" }}
+  {{ else if $isSingleResourcePage }}
+    {{ $type = "Dataset" }}
+  {{ else if $isResourcesPage }}
+    {{ $type = "DataCatalog" }}
+  {{ else if $isSingleServicePage }}
+    {{ $type = "Dataset" }}
+  {{ else if $isServicesPage }}
+    {{ $type = "DataCatalog" }}
+  {{ end }}
+  
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org/",
+    "@type": "{{ $type }}",
+    "url": "{{ .Permalink }}",
+    "name": "{{ if .Title }}{{ .Title | htmlEscape }}{{ else }}{{ $name | htmlEscape }}{{ end }}",
+    "image": "{{ if .Params.banner }}{{ .Params.banner | absURL }}{{ else }}{{ $image }}{{ end }}",
+    "description": "{{ $description | htmlEscape }}",
+    "keywords": [
+    {{- if or $isHighlightsPage $isSingleHighlightPage -}}
+      "SARS-CoV-2",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q82069695"
+      },
+      "COVID-19",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q84263196"
+      },
+      "Public health data",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q189603"
+      },
+      "Protein data",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q7251429"
+      },
+      "Data Sharing",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q5227350"
+      },
+      "Study result",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q107296061"
+      },
+      "Transcriptomics",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q28946449"
+      }
+      {{- else if or $isResourcesPage $isSingleResourcePage -}}
+      "Data sources",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q121566744"
+      },
+      "Research tools",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q71906510"
+      },
+      "Storage",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q744980"
+      },
+      "Data Storage",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q57515336"
+      },
+      "High-performance computing",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1190465"
+      },
+      "Data analysis",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1988917"
+      },
+      "Research tool",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q110994345"
+      },
+      "Datasets",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1172284"
+      }
+    {{- else if or $isServicesPage $isSingleServicePage -}}
+      "Services catalog",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q7455731"
+      },
+      "Service",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q7406919"
+      },
+      "Web Service",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q193424"
+      },
+      "AI Service in Life science",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q124256598"
+      },
+      "data integration",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q386824"
+      },
+      "Open source services",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q121705136"
+      },
+      "Web Portal",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q186165"
+      },
+      "nf-core",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q112320760"
+      },
+      "data stewardship",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q57450885"
+      },
+      "Swedish Pathogens Portal",
+      {
+        "@type": "URL",
+        "@value": "https://www.pathogens.se/"
+      },
+    {{- else if $isHomePage -}}
+      "SciLifeLab",
+      {
+        "@type": "URL",
+        "@value": "https://scilifelab.se/"
+      },
+      "Data-driven life science",
+      {
+        "@type": "URL",
+        "@value": "https://www.scilifelab.se/data-driven/"
+      },
+      "Research infrastructure",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1438053"
+      },
+      "Bioinformatics",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q128570"
+      },
+      "Data management", 
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1149776"
+      },
+      "Open science", 
+      {
+        "@type": "URL", 
+        "@value": "https://www.wikidata.org/wiki/Q309823"
+      },
+      "FAIR data",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q29032648"
+      }
+    {{- else -}}
+      "SciLifeLab",
+      {
+        "@type": "URL",
+        "@value": "https://scilifelab.se/"
+      },
+      "Life science research",
+      "Life sciences",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q864928"
+      },
+      "Open science", 
+      {
+        "@type": "URL", 
+        "@value": "https://www.wikidata.org/wiki/Q309823"
+      },
+      "FAIR data",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q29032648"
+      },
+      "Service",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q7406919"
+      },
+      "resource",
+      {
+        "@type": "URL",
+        "@value": "https://www.wikidata.org/wiki/Q1554231"
+      },      
+    {{- end }}
+  ],
+  
+    {{- /* If this is NOT a Dataset => creator block. Otherwise => includedInDataCatalog. */ -}}
+    {{- if ne $type "Dataset" }},
+    "creator": {
+      "@type": "Organization",
+      "@id": "https://www.scilifelab.se/",
+      "name": "SciLifeLab",
+      "address": "Tomtebodavägen 23, 171 65 Solna, Sweden",
+      "email": "info@scilifelab.se",
+      "url": "https://www.scilifelab.se/",
+      "description": "Science for Life Laboratory (SciLifeLab) is an institution for the advancement of molecular biosciences in Sweden. We are funded as a national research infrastructure by the Swedish government."
+    }
+    {{- else -}}
+    "includedInDataCatalog": {
+      "@id": "{{ with .Parent }}{{ .Permalink }}{{ end }}",
+      "@type": "DataCatalog",
+      "name": "SciLifeLab Data Catalog"
+    }
+    {{- end }}
+  }
+  </script>
+  

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,7 +1,7 @@
 {{/*
     schema.html
     This is the Schema partial for data.scilifelab.se
-    It generates relevant schema (WebSite, DataCatalog, or Dataset) and keywords
+    It generates relevant schema (WebSite, Collection, or Dataset) and keywords
     depending on whether the page is highlights/services/resources (single or listing).
   */}}
   
@@ -17,10 +17,8 @@
   {{ $isHomePage := .IsHome }}
   {{ $isSingleHighlightPage := and (eq $currentPage.Dir "/highlights/") ($currentPage.File) }}
   {{ $isHighlightsPage := and (strings.HasPrefix .RelPermalink "/highlights") (not $isSingleHighlightPage) }}
-  {{ $isSingleResourcePage := and (eq $currentPage.Dir "/resources/") ($currentPage.File) }}
-  {{ $isResourcesPage := and (strings.HasPrefix .RelPermalink "/resources") (not $isSingleResourcePage) }}
-  {{ $isSingleServicePage := and (eq $currentPage.Dir "/services/") ($currentPage.File) }}
-  {{ $isServicesPage := and (strings.HasPrefix .RelPermalink "/services") (not $isSingleServicePage) }}
+  {{ $isResourcesPage := strings.HasPrefix .RelPermalink "/resources" }}
+  {{ $isServicesPage := strings.HasPrefix .RelPermalink "/services" }}
   
   {{/* Overwrite $type based on page */}}
   {{ if $isHomePage }}
@@ -29,14 +27,8 @@
     {{ $type = "Dataset" }}
   {{ else if $isHighlightsPage }}
     {{ $type = "DataCatalog" }}
-  {{ else if $isSingleResourcePage }}
-    {{ $type = "Dataset" }}
-  {{ else if $isResourcesPage }}
-    {{ $type = "DataCatalog" }}
-  {{ else if $isSingleServicePage }}
-    {{ $type = "Dataset" }}
-  {{ else if $isServicesPage }}
-    {{ $type = "DataCatalog" }}
+  {{ else if or $isResourcesPage $isServicesPage }}
+    {{ $type = "Collection" }}
   {{ end }}
   
   <script type="application/ld+json">
@@ -84,7 +76,7 @@
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q28946449"
       }
-      {{- else if or $isResourcesPage $isSingleResourcePage -}}
+      {{- else if $isResourcesPage -}}
       "Data sources",
       {
         "@type": "URL",
@@ -125,7 +117,7 @@
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q1172284"
       }
-    {{- else if or $isServicesPage $isSingleServicePage -}}
+    {{- else if $isServicesPage -}}
       "Services catalog",
       {
         "@type": "URL",
@@ -176,43 +168,7 @@
         "@type": "URL",
         "@value": "https://www.pathogens.se/"
       },
-    {{- else if $isHomePage -}}
-      "SciLifeLab",
-      {
-        "@type": "URL",
-        "@value": "https://scilifelab.se/"
-      },
-      "Data-driven life science",
-      {
-        "@type": "URL",
-        "@value": "https://www.scilifelab.se/data-driven/"
-      },
-      "Research infrastructure",
-      {
-        "@type": "URL",
-        "@value": "https://www.wikidata.org/wiki/Q1438053"
-      },
-      "Bioinformatics",
-      {
-        "@type": "URL",
-        "@value": "https://www.wikidata.org/wiki/Q128570"
-      },
-      "Data management", 
-      {
-        "@type": "URL",
-        "@value": "https://www.wikidata.org/wiki/Q1149776"
-      },
-      "Open science", 
-      {
-        "@type": "URL", 
-        "@value": "https://www.wikidata.org/wiki/Q309823"
-      },
-      "FAIR data",
-      {
-        "@type": "URL",
-        "@value": "https://www.wikidata.org/wiki/Q29032648"
-      }
-    {{- else -}}
+    {{- end }}
       "SciLifeLab",
       {
         "@type": "URL",
@@ -243,8 +199,7 @@
       {
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q1554231"
-      },      
-    {{- end }}
+      },
   ],
   
     {{- /* If this is NOT a Dataset => creator block. Otherwise => includedInDataCatalog. */ -}}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -17,8 +17,8 @@
   {{ $isHomePage := .IsHome }}
   {{ $isSingleHighlightPage := and (eq $currentPage.Dir "/highlights/") ($currentPage.File) }}
   {{ $isHighlightsPage := and (strings.HasPrefix .RelPermalink "/highlights") (not $isSingleHighlightPage) }}
-  {{ $isResourcesPage := strings.HasPrefix .RelPermalink "/resources" }}
-  {{ $isServicesPage := strings.HasPrefix .RelPermalink "/services" }}
+  {{ $isResourcesPage := strings.HasSuffix .RelPermalink "/resources/" }}
+  {{ $isServicesPage := strings.HasSuffix .RelPermalink "/services/" }}
   
   {{/* Overwrite $type based on page */}}
   {{ if $isHomePage }}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -199,7 +199,7 @@
       {
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q1554231"
-      },
+      }
   ]  
     {{- /* If this is NOT a Dataset => creator block. Otherwise => includedInDataCatalog. */ -}}
     {{- if ne $type "Dataset" }},

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -75,7 +75,7 @@
       {
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q28946449"
-      }
+      },
       {{- else if $isResourcesPage -}}
       "Data sources",
       {
@@ -116,7 +116,7 @@
       {
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q1172284"
-      }
+      },
     {{- else if $isServicesPage -}}
       "Services catalog",
       {
@@ -200,8 +200,7 @@
         "@type": "URL",
         "@value": "https://www.wikidata.org/wiki/Q1554231"
       },
-  ],
-  
+  ]  
     {{- /* If this is NOT a Dataset => creator block. Otherwise => includedInDataCatalog. */ -}}
     {{- if ne $type "Dataset" }},
     "creator": {
@@ -213,7 +212,7 @@
       "url": "https://www.scilifelab.se/",
       "description": "Science for Life Laboratory (SciLifeLab) is an institution for the advancement of molecular biosciences in Sweden. We are funded as a national research infrastructure by the Swedish government."
     }
-    {{- else -}}
+    {{- else -}},
     "includedInDataCatalog": {
       "@id": "{{ with .Parent }}{{ .Permalink }}{{ end }}",
       "@type": "DataCatalog",


### PR DESCRIPTION
This pull request introduces the addition of Schema.org structured data to the website, which will help improve SEO and provide better data to search engines. The changes include modifications to the `layouts/partials/head.html` and the creation of a new partial, `schema.html`, which generates the appropriate schema based on the type of page being viewed.

Closes [FREYA-663](https://scilifelab.atlassian.net/browse/FREYA-663)