### PR TITLE
FREYA-1235: Add OpenScience GitHub team as codeowners of their content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @ScilifelabDataCentre/teamfreya
+/content/open_science/ @ScilifelabDataCentre/OpenScience
+/static/img/open_science/ @ScilifelabDataCentre/OpenScience
+/data/open_science/ @ScilifelabDataCentre/OpenScience
+


### PR DESCRIPTION
- Open Science own their content (markdown, images, data files) on this site.

The purpose is to auto-select the right group of people for code reviews (i.e. not have Freya be reviewers, unless requested, on the content files for Open Science). I'd suggest that in the start someone from Freya would be a reviewer but that would be just at the start. 