### PR TITLE
Freya-1342: Add git commit message template

### DIFF
--- a/.github/.gitmessage.txt
+++ b/.github/.gitmessage.txt
@@ -1,0 +1,1 @@
+# <type>(scope): <short description>

--- a/.github/.gitmessage.txt
+++ b/.github/.gitmessage.txt
@@ -1,5 +1,10 @@
 # <type>(scope): <short description>
 
+# Example Commit Messages:
+# feat(auth): add user authentication system
+# fix(api): resolve login endpoint timeout
+# docs(readme): update installation instructions
+
 # Example types:
 # feat     - A new feature or capability
 # fix      - A bug fix
@@ -18,8 +23,3 @@
 # deps     - Dependency updates
 # docs     - Documentation changes
 # ci       - CI/CD pipeline changes
-
-# Example Commit Messages:
-# feat(auth): add user authentication system
-# fix(api): resolve login endpoint timeout
-# docs(readme): update installation instructions

--- a/.github/.gitmessage.txt
+++ b/.github/.gitmessage.txt
@@ -1,1 +1,25 @@
 # <type>(scope): <short description>
+
+# Example types:
+# feat     - A new feature or capability
+# fix      - A bug fix
+# docs     - Documentation-only changes
+# style    - Formatting-only changes (no logic change)
+# refactor - A code change that neither fixes a bug nor adds a feature
+# perf     - Performance improvements
+# test     - Adding or correcting tests
+# build    - Build system or dependency changes
+# ci       - CI/CD configuration or scripts
+# chore    - Maintenance, tooling, or infrastructure changes
+# revert   - Reverts a previous commit
+
+# Example Scope:
+# ui       - User interface components
+# deps     - Dependency updates
+# docs     - Documentation changes
+# ci       - CI/CD pipeline changes
+
+# Example Commit Messages:
+# feat(auth): add user authentication system
+# fix(api): resolve login endpoint timeout
+# docs(readme): update installation instructions

--- a/.github/.gitmessage.txt
+++ b/.github/.gitmessage.txt
@@ -8,15 +8,10 @@
 # Example types:
 # feat     - A new feature or capability
 # fix      - A bug fix
+# content  - New content such as markdown pages under `content` directory
 # docs     - Documentation-only changes
-# style    - Formatting-only changes (no logic change)
-# refactor - A code change that neither fixes a bug nor adds a feature
-# perf     - Performance improvements
 # test     - Adding or correcting tests
-# build    - Build system or dependency changes
-# ci       - CI/CD configuration or scripts
 # chore    - Maintenance, tooling, or infrastructure changes
-# revert   - Reverts a previous commit
 
 # Example Scope:
 # ui       - User interface components

--- a/README.md
+++ b/README.md
@@ -79,11 +79,22 @@ Then you can fetch changes at any time from this remote:
 git pull upstream develop
 ```
 
+#### Configure Commit Message Template
+
+We follow a structured commit message format defined in [`.github/.gitmessage.txt`](.github/.gitmessage.txt). To use this template:
+
+```bash
+# you just need to run this command once after cloning repository
+git config --local commit.template .github/.gitmessage.txt
+```
+
+This will pre-fill your commit message editor with our lightweight conventional commit template whenever you run `git commit`.
+
 When you have finished editing, commit and push to your fork:
 
 ```bash
 git add .
-git commit -m "My changes"
+git commit  # This will open your editor with the template
 git push
 ```
 


### PR DESCRIPTION
### 📋 Summary
This PR introduces a `.gitmessage.txt` file that provides a standardized, lightweight conventional commit template for contributors to follow while working on feature branches.

The goal is to improve commit consistency across the team and support our evolving Git workflow, which includes structured squash commits for merging into develop.

###  ⚙️ How to Configure the Commit Template Locally
After pulling this change, contributors can configure Git to use this commit message template by running the following command in the root of the repo:
`git config --local commit.template .github/.gitmessage.txt`

This will cause Git to pre-fill your commit message editor with the template whenever you run:
`git commit`

✅ Tip: Use this during development to follow our lightweight conventional commit structure.