### PR TITLE
Update hugo version

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # Use alpine Linux, download desired version of HUGO and build html files
 FROM alpine:3.21 AS build
 RUN apk add --no-cache wget
-ARG HUGO_VERSION="0.145.0"
+ARG HUGO_VERSION="0.147.3"
 ARG HUGO_ENV_ARG
 WORKDIR /src
 COPY ./ /src

--- a/content/sv/_index.md
+++ b/content/sv/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Om SciLifeLab Data Platform
-lang: sv
+language: sv
 toc: true
 menu:
     bottom_about:

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,4 +1,4 @@
 <aside class="sticky-top toc pt-2 fs-6">
-    <h5>{{ if eq .Params.lang "sv" }}Innehåll:{{ else }}On this page:{{ end }}</h5>
+    <h5>{{ if eq .Params.language "sv" }}Innehåll:{{ else }}On this page:{{ end }}</h5>
     {{ .TableOfContents }}
 </aside>


### PR DESCRIPTION
Updating `hugo` version to the latest, and made some tweaks as there a `warn` message (see below).

```
WARN deprecated: lang in front matter was deprecated in Hugo v0.144.0 and will be removed in a future release.
```

