### PR TITLE
FREYA-1232 Open Science Linting: Fix markdownlint errors in Open Science content

### DIFF
--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -3,6 +3,6 @@ config:
   MD025: false
   MD051: false
   line-length:
-    line_length: 120
+    line_length: 180
   no-inline-html: false
   

--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -1,5 +1,6 @@
 config:
   default: true
+  MD001: false
   MD025: false
   MD051: false
   line-length:

--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -1,6 +1,7 @@
 config:
   default: true
   MD025: false
+  MD051: false
   line-length:
     line_length: 120
   no-inline-html: false

--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -1,5 +1,6 @@
 config:
   default: true
+  MD025: false
   line-length:
     line_length: 120
   no-inline-html: false

--- a/content/open_science/_index.md
+++ b/content/open_science/_index.md
@@ -12,7 +12,7 @@ menu:
     weight: 1
 ---
 
-# Overview 
+# Overview
 
 {{< video_banner
   video="/media/open_science/index.mp4"

--- a/content/open_science/_index.md
+++ b/content/open_science/_index.md
@@ -19,17 +19,19 @@ menu:
   alt="A looping animation showing scenes from a wet lab."
 >}}
 
-At SciLifeLab, the Open Science team is dedicated to equipping researchers with the tools and resources needed to leverage
-Open Science practices effectively. We aim to foster a culture of openness and integrate Open Science principles into our
-systems and research workflows.
+At SciLifeLab, the Open Science team is dedicated to equipping researchers with the tools and resources needed to
+leverage Open Science practices effectively. We aim to foster a culture of openness and integrate Open Science
+principles into our systems and research workflows.
 
 We support researchers by providing guidance to help make their research outputs discoverable, accessible, and properly
 credited through open access publishing and community-trusted repositories. By promoting transparency, we encourage fair
 attribution, ethical sharing, and responsible research practices.
 
 Our team stays informed on Open Science policies and guidelines at the national, international, and funder levels,
-integrating these with SciLifeLab’s policies. We also work to coordinate and support communities that promote collaboration
-around [Open Science](https://www.unesco.org/en/open-science/about?hub=686) and [FAIR principles](https://www.nature.com/articles/sdata201618).
+integrating these with SciLifeLab’s policies. We also work to coordinate and support communities that promote
+collaboration
+around [Open Science](https://www.unesco.org/en/open-science/about?hub=686) and
+[FAIR principles](https://www.nature.com/articles/sdata201618).
 
 Our goal is to provide practical, straightforward guidance on how to navigate these evolving requirements, integrating
 them into onboarding, systems, and training. Ultimately, we aim to drive cultural change toward FAIR and Open Science,

--- a/content/open_science/glossary.md
+++ b/content/open_science/glossary.md
@@ -6,6 +6,6 @@ menu:
     weight: 5
 ---
 
-# Glossary 
+# Glossary
 
 {{< glossary "open_science/glossary" >}}

--- a/content/open_science/initiatives/_index.md
+++ b/content/open_science/initiatives/_index.md
@@ -9,16 +9,16 @@ menu:
 
 # Initiatives
 
-### Our Initiatives
+## Our Initiatives
 
 At SciLifeLab, we are dedicated to facilitating collaboration, driving innovation, and empowering the
-scientific community through Open Science practices and the FAIR principles. Our initiatives focus on creating impactful,
-researcher-driven solutions to enhance data sharing, discovery, and reuse across life sciences. You can view some of
-the ongoing and upcoming initiatives that we are involved in below.
+scientific community through Open Science practices and the FAIR principles. Our initiatives focus on creating
+impactful, researcher-driven solutions to enhance data sharing, discovery, and reuse across life sciences. You can view
+some of the ongoing and upcoming initiatives that we are involved in below.
 
 {{< simple_cards "open_science/initiatives" >}}
 
-### Collaborative Initiatives
+## Collaborative Initiatives
 
 SciLifeLab is proud to support and advance a range of initiatives that align with our commitment to Open Science,
 FAIR principles, and the sustainable development of research infrastructure. You can view some of the ongoing and
@@ -26,7 +26,7 @@ upcoming initiatives that we are involved in below.
 
 {{< simple_cards "open_science/collaborative_initiatives" >}}
 
-### SciLifeLab Initiatives
+## SciLifeLab Initiatives
 
 There are many innovative Open Science initiatives throughout SciLifeLab, and
 [this page](/open_science/initiatives/scilifelab) offers a space for these projects to be highlighted.

--- a/content/open_science/initiatives/_index.md
+++ b/content/open_science/initiatives/_index.md
@@ -26,7 +26,7 @@ upcoming initiatives that we are involved in below.
 
 {{< simple_cards "open_science/collaborative_initiatives" >}}
 
-### SciLifeLab Initiatives 
+### SciLifeLab Initiatives
 
 There are many innovative Open Science initiatives throughout SciLifeLab, and
 [this page](/open_science/initiatives/scilifelab) offers a space for these projects to be highlighted.

--- a/content/open_science/initiatives/collaborative.md
+++ b/content/open_science/initiatives/collaborative.md
@@ -44,8 +44,8 @@ We are actively working to implement CoARA’s principles at both national and i
 collaborative approach, we hope to move beyond traditional, publication-based metrics and promote more inclusive
 evaluation practices that recognise the full range of research contributions.
 
-You can review SciLifeLab’s CoARA Action Plan
-[here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
+You can review SciLifeLab’s CoARA Action Plan in this
+[document on Google Docs](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
 
 ### Why SciLifeLab Joined CoARA
 
@@ -68,8 +68,8 @@ You can review SciLifeLab’s CoARA Action Plan
 ## Global Alliance for Genomics and Health (GA4GH) {#ga4gh}
 
 SciLifeLab is collaborating with GA4GH to advance responsible sharing of genomic and health data through standards,
-policy frameworks, and harmonised approaches. Discover more about GA4GH and the work they are doing to promote the
-responsible sharing of genomic data [here](https://www.ga4gh.org/).
+policy frameworks, and harmonised approaches. Discover more about GA4GH and the work they are doing to promote the  
+responsible sharing of genomic data on the [GA4GH official website](https://www.ga4gh.org/).
 
 ### GA4GH 13th Plenary Meeting
 
@@ -81,8 +81,8 @@ as well as have the opportunity to explore GA4GH technical standards and policie
 scalable solutions for genomic and health data sharing. Guided by an international Programme Committee and shaped by
 input from the broader GA4GH community, this plenary aims to foster global collaboration in genomic science to improve
 health outcomes worldwide.
-You can learn more and register for the GA4GH 13th Plenary Meeting
-[here](https://broadinstitute.swoogo.com/ga4gh13plenary/7101555)
+You can learn more and register for the GA4GH 13th Plenary Meeting on the
+[event page](https://broadinstitute.swoogo.com/ga4gh13plenary/7101555)
 
 {{< banner_image
   image="/img/open_science/initiatives/adore.png"
@@ -102,8 +102,8 @@ It builds on prior initiatives by the [Research Software Alliance](https://www.r
 [Research Software Funders Forum](https://www.researchsoft.org/funders-forum/), among others to formalise global
 principles and recommendations for funding research software sustainability.
 
-Discover more about ADORE.software [here](https://adore.software/) and Become a Signatory for the declaration
-[here](https://adore.software/get-involved/).
+Discover more about [ADORE.software](https://adore.software/) and become a signatory to the declaration on the
+[Get Involved page](https://adore.software/get-involved/).
 
 ### Importance of ADORE.software for SciLifeLab
 
@@ -191,7 +191,7 @@ primary goal is to facilitate the sharing, discovery, and reuse of research data
 collaboration and accelerating scientific progress. EOSC builds upon existing infrastructures and services supported
 by the European Commission, Member States, and research communities, integrating them into a cohesive 'system of
 systems' to add value by aggregating content and enabling services to be used together.
-You can read more about EOSC [here](https://eosc.eu/).
+You can read more about EOSC on the [EOSC website](https://eosc.eu/).
 
 SciLifeLab actively collaborates with EOSC by providing feedback to the EOSC EU Node and participating in
 [several task forces](https://eosc.eu/eosc-task-forces/). It works closely with university partners such as Uppsala

--- a/content/open_science/initiatives/collaborative.md
+++ b/content/open_science/initiatives/collaborative.md
@@ -23,7 +23,8 @@ Guided by a common set of principles and commitments, CoARA fosters collaboratio
 learning to promote more inclusive and effective research evaluation practices.
 Traditional assessment methods rely heavily on publication-based metrics, such as citation counts and journal impact
 factor, which can overlook the diverse contributions of researchers. CoARA seeks to address this by promoting principles
-and guidelines outlined in the [Agreement on Reforming Research Assessment](https://coara.eu/app/uploads/2022/09/2022_07_19_rra_agreement_final.pdf),
+and guidelines outlined in the
+[Agreement on Reforming Research Assessment](https://coara.eu/app/uploads/2022/09/2022_07_19_rra_agreement_final.pdf),
 published in July 2022, which offers a foundation for the reformation of current research assessment practices, to
 recognise all aspects of research contributions.
 
@@ -32,7 +33,8 @@ recognise all aspects of research contributions.
 ### CoARA Action Plan for SciLifeLab: A Path Towards Recognising Diverse Contributions to Research Through Open Science and the FAIR Principles
 
 On 23 February 2024, SciLifeLab announced its collaboration with CoARA, reaffirming our commitment to advancing research
-assessment and open science practices within our work. In partnership with the [CoARA Swedish National Chapter](https://coara.eu/working-groups/national-chapters/coara-national-chapter-sweden/),
+assessment and open science practices within our work. In partnership with the
+[CoARA Swedish National Chapter](https://coara.eu/working-groups/national-chapters/coara-national-chapter-sweden/),
 SciLifeLab established a new CoARA-SciLifeLab [Working Group](https://coara.eu/working-groups/working-groups/) to
 develop actionable steps which align with CoARA’s objectives.
 
@@ -42,17 +44,20 @@ We are actively working to implement CoARA’s principles at both national and i
 collaborative approach, we hope to move beyond traditional, publication-based metrics and promote more inclusive
 evaluation practices that recognise the full range of research contributions.
 
-You can review SciLifeLab’s CoARA Action Plan [here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
+You can review SciLifeLab’s CoARA Action Plan
+[here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
 
-### Why SciLifeLab Joined CoARA:
+### Why SciLifeLab Joined CoARA
 
 - **Alignment with EU and EC Initiatives**: Participation with CoARA aligns with broader European Union and European
   Commission collaborations on research evaluation reform.
-- **Open Science Implementation in Our Practices at SciLifeLab**: Commitment to incorporating Open Science principles into
+- **Open Science Implementation in Our Practices at SciLifeLab**: Commitment to incorporating Open Science principles
+  into
   reporting, recruitment and awards at SciLifeLab.
 - **Commitment to Reform Research Assessment**: Support for CoARA's principles of reforming traditional research
   assessment methods, moving beyond publication-based metrics to recognise diverse research contributions.
-- **Alignment with Swedish Institutions**: Over 30 Swedish universities, including KI, SU, KTH, and UU, have joined CoARA,
+- **Alignment with Swedish Institutions**: Over 30 Swedish universities, including KI, SU, KTH, and UU, have joined
+  CoARA,
   providing an opportunity for national collaboration and consistency.
 
 {{< banner_image
@@ -74,8 +79,10 @@ and drive progress in genomic data sharing to advance human health.
 Over the course of the week, attendees will participate in collaborative workshops, presentations, and keynote talks,
 as well as have the opportunity to explore GA4GH technical standards and policies, exchange insights, and create
 scalable solutions for genomic and health data sharing. Guided by an international Programme Committee and shaped by
-input from the broader GA4GH community, this plenary aims to foster global collaboration in genomic science to improve health outcomes worldwide.
-You can learn more and register for the GA4GH 13th Plenary Meeting [here](https://broadinstitute.swoogo.com/ga4gh13plenary/7101555)
+input from the broader GA4GH community, this plenary aims to foster global collaboration in genomic science to improve
+health outcomes worldwide.
+You can learn more and register for the GA4GH 13th Plenary Meeting
+[here](https://broadinstitute.swoogo.com/ga4gh13plenary/7101555)
 
 {{< banner_image
   image="/img/open_science/initiatives/adore.png"
@@ -95,21 +102,26 @@ It builds on prior initiatives by the [Research Software Alliance](https://www.r
 [Research Software Funders Forum](https://www.researchsoft.org/funders-forum/), among others to formalise global
 principles and recommendations for funding research software sustainability.
 
-Discover more about ADORE.software [here](https://adore.software/) and Become a Signatory for the declaration [here](https://adore.software/get-involved/).
+Discover more about ADORE.software [here](https://adore.software/) and Become a Signatory for the declaration
+[here](https://adore.software/get-involved/).
 
 ### Importance of ADORE.software for SciLifeLab
 
-- **Collaborating with Global Stakeholders**: With over 45 funding organisations participating in the first Amsterdam meeting,
+- **Collaborating with Global Stakeholders**: With over 45 funding organisations participating in the first Amsterdam
+  meeting,
   including [Wellcome](https://wellcome.org/), [Sloan Foundation](https://sloan.org/),
   the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) (CZI), and [NWO](https://www.nwo.nl/en)
   (The Dutch Research Council), SciLifeLab has the opportunity to engage with leading funders, agencies, and
   infrastructure providers to shape the future of research software sustainability.
 - **Building Connections**: SciLifeLab is connecting with key research software communities, including Research Software
-  Engineers and Open Source Program Offices, to contribute to programs that reward, recognise, and sustain software development,
+  Engineers and Open Source Program Offices, to contribute to programs that reward, recognise, and sustain software
+  development,
   such as those led by CZI.
-- **Advancing Data Science and Scholarly Workflows**: By participating in discussions and initiatives, SciLifeLab aims to learn
+- **Advancing Data Science and Scholarly Workflows**: By participating in discussions and initiatives, SciLifeLab aims
+  to learn
   and adopt best practices for advancing data science and enhancing scholarly workflows through sustainable software.
-- **Leading in Sweden and Beyond**: SciLifeLab is uniquely positioned to guide the operationalisation and implementation of
+- **Leading in Sweden and Beyond**: SciLifeLab is uniquely positioned to guide the operationalisation and implementation
+  of
   ADORE.software in Sweden.
 
 {{< banner_image
@@ -125,12 +137,13 @@ the equitable and privacy preserving reuse of data and services. SciLifeLab host
 a transatlantic collaboration with GO FAIR US and the [San Diego Supercomputer Center](https://www.sdsc.edu/), where we
 collaborate on FAIR assessment projects (e.g., with [NIH NIAID](https://www.niaid.nih.gov/)). These initiatives share a
 common goal of improving FAIR assessment and certification, and joining the network allows us to look at how we can
-improve the FAIRness of SciLifeLab systems through our community programs. You can view our community initiatives [here](#our-initiatives-our-initiatives).
+improve the FAIRness of SciLifeLab systems through our community programs. You can
+[view our community initiatives here](#our-initiatives-our-initiatives).
 
 Through these initiatives, SciLifeLab aims to strengthen Sweden’s position as a global leader in open science,
 sustainable research practices, and data-driven innovation.
 
-Read more about LIFES and GO FAIR [here](https://www.gofair.foundation/lifes).
+[Read more about LIFES and GO FAIR here](https://www.gofair.foundation/lifes).
 
 {{< banner_image
   image="/img/open_science/initiatives/osmi.png"
@@ -139,7 +152,8 @@ Read more about LIFES and GO FAIR [here](https://www.gofair.foundation/lifes).
 
 ## Open Science Monitoring Initiative {#osmi}
 
-SciLifeLab is proud to partner with the [Open Science Monitoring Initiative (OSMI)](https://open-science-monitoring.org/)
+SciLifeLab is proud to partner with the
+[Open Science Monitoring Initiative (OSMI)](https://open-science-monitoring.org/)
 to support the adoption and advancement of Open Science monitoring practices. OSMI brings together individuals and
 institutions worldwide to collaboratively develop frameworks for monitoring Open Science.
 The initiative was inspired by the May 2023 G7 Science and Technology Ministers’ meeting in Sendai, where the ministers

--- a/content/open_science/initiatives/collaborative.md
+++ b/content/open_science/initiatives/collaborative.md
@@ -45,14 +45,15 @@ evaluation practices that recognise the full range of research contributions.
 You can review SciLifeLab’s CoARA Action Plan [here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
 
 ### Why SciLifeLab Joined CoARA:
-- **Alignment with EU and EC Initiatives**: Participation with CoARA aligns with broader European Union and European 
-  Commission collaborations on research evaluation reform. 
-- **Open Science Implementation in Our Practices at SciLifeLab**: Commitment to incorporating Open Science principles into 
-  reporting, recruitment and awards at SciLifeLab. 
+
+- **Alignment with EU and EC Initiatives**: Participation with CoARA aligns with broader European Union and European
+  Commission collaborations on research evaluation reform.
+- **Open Science Implementation in Our Practices at SciLifeLab**: Commitment to incorporating Open Science principles into
+  reporting, recruitment and awards at SciLifeLab.
 - **Commitment to Reform Research Assessment**: Support for CoARA's principles of reforming traditional research
-  assessment methods, moving beyond publication-based metrics to recognise diverse research contributions. 
+  assessment methods, moving beyond publication-based metrics to recognise diverse research contributions.
 - **Alignment with Swedish Institutions**: Over 30 Swedish universities, including KI, SU, KTH, and UU, have joined CoARA,
-  providing an opportunity for national collaboration and consistency. 
+  providing an opportunity for national collaboration and consistency.
 
 {{< banner_image
   image="/img/open_science/initiatives/ga4gh.png"
@@ -69,11 +70,11 @@ responsible sharing of genomic data [here](https://www.ga4gh.org/).
 
 As a part of this partnership, SciLifeLab will host the GA4GH 13th Plenary Meeting in October 2025 in Uppsala, Sweden.
 This event will bring together the global genomics community to address shared challenges, develop innovative solutions,
-and drive progress in genomic data sharing to advance human health. 
+and drive progress in genomic data sharing to advance human health.
 Over the course of the week, attendees will participate in collaborative workshops, presentations, and keynote talks,
 as well as have the opportunity to explore GA4GH technical standards and policies, exchange insights, and create
 scalable solutions for genomic and health data sharing. Guided by an international Programme Committee and shaped by
-input from the broader GA4GH community, this plenary aims to foster global collaboration in genomic science to improve health outcomes worldwide. 
+input from the broader GA4GH community, this plenary aims to foster global collaboration in genomic science to improve health outcomes worldwide.
 You can learn more and register for the GA4GH 13th Plenary Meeting [here](https://broadinstitute.swoogo.com/ga4gh13plenary/7101555)
 
 {{< banner_image
@@ -99,9 +100,9 @@ Discover more about ADORE.software [here](https://adore.software/) and Become a 
 ### Importance of ADORE.software for SciLifeLab
 
 - **Collaborating with Global Stakeholders**: With over 45 funding organisations participating in the first Amsterdam meeting,
-  including [Wellcome](https://wellcome.org/), [Sloan Foundation](https://sloan.org/), 
-  the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) (CZI), and [NWO](https://www.nwo.nl/en) 
-  (The Dutch Research Council), SciLifeLab has the opportunity to engage with leading funders, agencies, and 
+  including [Wellcome](https://wellcome.org/), [Sloan Foundation](https://sloan.org/),
+  the [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) (CZI), and [NWO](https://www.nwo.nl/en)
+  (The Dutch Research Council), SciLifeLab has the opportunity to engage with leading funders, agencies, and
   infrastructure providers to shape the future of research software sustainability.
 - **Building Connections**: SciLifeLab is connecting with key research software communities, including Research Software
   Engineers and Open Source Program Offices, to contribute to programs that reward, recognise, and sustain software development,
@@ -175,8 +176,8 @@ multidisciplinary digital environment for European researchers, academics, innov
 primary goal is to facilitate the sharing, discovery, and reuse of research data, tools, and services, fostering
 collaboration and accelerating scientific progress. EOSC builds upon existing infrastructures and services supported
 by the European Commission, Member States, and research communities, integrating them into a cohesive 'system of
-systems' to add value by aggregating content and enabling services to be used together. 
-You can read more about EOSC [here](https://eosc.eu/). 
+systems' to add value by aggregating content and enabling services to be used together.
+You can read more about EOSC [here](https://eosc.eu/).
 
 SciLifeLab actively collaborates with EOSC by providing feedback to the EOSC EU Node and participating in
 [several task forces](https://eosc.eu/eosc-task-forces/). It works closely with university partners such as Uppsala

--- a/content/open_science/initiatives/our_initiatives.md
+++ b/content/open_science/initiatives/our_initiatives.md
@@ -50,7 +50,8 @@ Through discussions, roundtables, and a dedicated Slack community, the initiativ
 and expand its reach, strengthening data integration, discovery, and reuse. By doing so, it advances innovation in life
 science research by facilitating more effective and connected research data.
 
-You can read more about the work that is being done [here](https://docs.google.com/presentation/d/1aapjARKgO-IBNCUrrILlqYyKVJxmUoqRMvO5IZaHs_I/edit#slide=id.g32233462cdb_0_199).
+You can read more about the work that is being done in this
+[presentation](https://docs.google.com/presentation/d/1aapjARKgO-IBNCUrrILlqYyKVJxmUoqRMvO5IZaHs_I/edit#slide=id.g32233462cdb_0_199).
 
 {{< banner_image
   image="/img/open_science/initiatives/osmonitor.png"

--- a/content/open_science/initiatives/our_initiatives.md
+++ b/content/open_science/initiatives/our_initiatives.md
@@ -38,7 +38,8 @@ Accessible, Interoperable, Reusable), to enhance data interoperability and suppo
 
 The initiative seeks to understand how standards are being adopted, and the barriers preventing adoption, across
 research domains, institutions, and funding agencies. This will be achieved by building expertise and fostering
-collaborations among SciLifeLab [researchers](https://www.scilifelab.se/research/), [fellows](https://www.scilifelab.se/contact/fellows/),
+collaborations among SciLifeLab [researchers](https://www.scilifelab.se/research/),
+[fellows](https://www.scilifelab.se/contact/fellows/),
 and [infrastructure](https://www.scilifelab.se/services/infrastructure/) experts.
 
 It addresses shared challenges in metadata management, including standards, curation, and discovery, while promoting

--- a/content/open_science/initiatives/our_initiatives.md
+++ b/content/open_science/initiatives/our_initiatives.md
@@ -7,7 +7,7 @@ menu:
     weight: 1
 ---
 
-# Our Initiatives 
+# Our Initiatives
 
 {{< banner_image
   image="/img/open_science/initiatives/cop.png"
@@ -60,13 +60,13 @@ You can read more about the work that is being done [here](https://docs.google.c
 
 At SciLifeLab, we monitor the compliance with Open Science and FAIR principles, as displayed in the
 [annual report](https://www.scilifelab.se/about-us/management/all-reports/#h-annual-reports), which reviews the research
-produced by our infrastructure units and affiliated researchers. As this process is highly resource intensive, we are 
+produced by our infrastructure units and affiliated researchers. As this process is highly resource intensive, we are
 procuring a software service to support large-scale, automated, and in-depth analysis of the publications and research
 outputs produced by SciLifeLab.
 
-The Open Science Monitoring Initiative aims to implement an automated solution for tracking Open Science indicators. 
-Our initial focus is on analysing the data and software shared in SciLifeLab publications. By mining this information, 
-we will assess how closely our community aligns with Open Science practices, policies, and guidelines. Using this 
+The Open Science Monitoring Initiative aims to implement an automated solution for tracking Open Science indicators.
+Our initial focus is on analysing the data and software shared in SciLifeLab publications. By mining this information,
+we will assess how closely our community aligns with Open Science practices, policies, and guidelines. Using this
 information, we will develop an interactive dashboard to help the community explore, interpret, and engage with the
 findings.
 

--- a/content/open_science/initiatives/scilifelab.md
+++ b/content/open_science/initiatives/scilifelab.md
@@ -7,7 +7,7 @@ menu:
     weight: 3
 ---
 
-# SciLifeLab Initiatives 
+# SciLifeLab Initiatives
 
 There are many innovative Open Science initiatives throughout SciLifeLab, and this page offers a space for these
 projects to be highlighted.
@@ -22,7 +22,7 @@ SciLifeLab is a founding member of [nf-core](https://nf-co.re/) - a community ef
 analysis pipelines and modules built using Nextflow, aimed at enhancing reproducibility and collaboration. Different
 groups, especially [National Genomics Infrastructure (NGI)](https://ngisweden.scilifelab.se/), are supporting both the
 community and the development of pipelines. SciLifeLab Data Centre contributes to the development of the infrastructure
-behind the initiative. 
+behind the initiative.
 
 <figure class="figure text-center">
   <img src="/img/open_science/initiatives/nf-core.png" class="figure-img img-fluid" alt="nf-core logo">
@@ -30,7 +30,7 @@ behind the initiative.
 
 {{< /image_text_row  >}}
 
-## Share your Open Science initiatives 
+## Share your Open Science initiatives
 
 If you are working on an Open Science project at SciLifeLab and would like to showcase your work, please contact us
 via email at [datacentre@scilifelab.se](mailto:datacentre@scilifelab.se) with the subject line 'Open Science'.

--- a/content/open_science/initiatives/scilifelab.md
+++ b/content/open_science/initiatives/scilifelab.md
@@ -12,10 +12,10 @@ menu:
 There are many innovative Open Science initiatives throughout SciLifeLab, and this page offers a space for these
 projects to be highlighted.
 
-{{< image_text_row 
-  image="/img/open_science/initiatives/nf-core_hackathon_2024.png" 
+{{< image_text_row
+  image="/img/open_science/initiatives/nf-core_hackathon_2024.png"
   alt="nf-core hackathon 2024"
-  title="SciLifeLab & nf-core" 
+  title="SciLifeLab & nf-core"
 >}}
 
 SciLifeLab is a founding member of [nf-core](https://nf-co.re/) - a community effort to collect a curated set of

--- a/content/open_science/open_science_stories.md
+++ b/content/open_science/open_science_stories.md
@@ -14,11 +14,11 @@ From code sharing to FAIR data, two of our new SciLifeLab/DDLS (Data Driven Life
 Science journeys. They highlight practical steps, benefits, and challenges of making research more transparent and
 accessible. Their stories showcase how Open Science fuels collaboration and accelerates discovery.
 
-{{< image_pair 
+{{< image_pair
   image1="/img/open_science/stories/golnaz.png"
   alt1="Photo of Golnaz Taheri"
   caption1="Golnaz Taheri (Assistant Professor, Division of Computational Science and Technology, EECS - KTH, DDLS Fellow)"
-  image2="/img/open_science/stories/miranda.png" 
+  image2="/img/open_science/stories/miranda.png"
   alt2="Photo of Gisele Miranda"
   caption2="Gisele Miranda (Assistant Professor, Division of Computational Science and Technology, EECS - KTH, SciLifeLab Fellow)"
   height=25rem
@@ -26,11 +26,12 @@ accessible. Their stories showcase how Open Science fuels collaboration and acce
 
 ### Can you introduce yourself and your current research focus?
 
-_Golnaz Taheri_: My name is Golnaz Taheri and I am currently an Assistant Professor at the Department of EECS (Electrical
-Engineering and Computer Science)/Division of CST (Computational Science and Technology) and a DDLS Fellow at SciLifeLab.
-I work in the field of computational biology, with a focus on applying machine learning to cancer biology and drug
-interaction prediction. My research involves analyzing multi-omics data and developing computational models to better
-understand complex biological systems, especially related to female cancers.
+_Golnaz Taheri_: My name is Golnaz Taheri and I am currently an Assistant Professor at the Department of EECS
+(Electrical
+Engineering and Computer Science)/Division of CST (Computational Science and Technology) and a DDLS Fellow at
+SciLifeLab. I work in the field of computational biology, with a focus on applying machine learning to cancer biology
+and drug interaction prediction. My research involves analyzing multi-omics data and developing computational models to
+better understand complex biological systems, especially related to female cancers.
 I also work on creating systematic frameworks for predicting drug interactions, aiming to improve the quality of life
 for patients dealing with multiple diseases, especially elderly individuals.
 
@@ -41,8 +42,9 @@ extract meaningful biological insights from complex datasets.
 
 ### Can you describe what Open Science means to you?
 
-_Golnaz Taheri_: To me, Open Science is about making research and data accessible, transparent, and collaborative. It goes
-beyond just sharing data; It involves using practices that allow others to reuse and build upon scientific work in an
+_Golnaz Taheri_: To me, Open Science is about making research and data accessible, transparent, and collaborative.
+It goes beyond just sharing data; It involves using practices that allow others to
+reuse and build upon scientific work in an
 ethical, responsible, and sustainable manner. Open Science enables a more inclusive research ecosystem by removing
 barriers to knowledge sharing. It also promotes reproducibility, transparency, and integrity in science, which
 ultimately leads to better, faster advancements in knowledge.
@@ -82,13 +84,14 @@ working on publishing this material in a more FAIR-compliant format.
 While I don’t often generate raw data myself, I work extensively with data already generated
 by the research community, and ensuring those are available for reuse is a key priority.
 
-### What were the biggest benefits or outcomes of sharing your work openly? (Did it lead to new collaborations, reuse of your data, or public engagement?
+### What were the biggest benefits or outcomes of sharing your work openly? (Did it lead to new collaborations, reuse of your data, or public engagement?)
 
-_Golnaz Taheri_: Sharing my work openly has been incredibly beneficial in terms of collaboration and data reuse. With the
-resources available through SciLifeLab, like Berzelius, NBIS, and Bianca, my data is accessible to the broader scientific
-community, which has led to new collaborations and the reuse of my data by researchers worldwide. The open access nature
-of the Swedish research environment, especially with support for journal publication fees, has made it easier for my work
-to be widely shared and engaged with by others.
+_Golnaz Taheri_: Sharing my work openly has been incredibly beneficial in terms of collaboration and data reuse. With
+the resources available through SciLifeLab, like Berzelius, NBIS, and Bianca, my data is accessible to the broader
+scientific community, which has led to new collaborations and the reuse of my data by researchers worldwide.
+The open access nature
+of the Swedish research environment, especially with support for journal publication fees,
+has made it easier for my work to be widely shared and engaged with by others.
 Moreover, the ability to share both my data and computational tools has enabled my research to have a greater impact,
 with multiple groups building upon my work in cancer biology. These collaborations have been key in advancing my
 research and helping me tackle more complex challenges.
@@ -103,11 +106,11 @@ our work more thoughtfully and ensuring that what we produce is accessible and m
 
 ### Did you face any challenges in doing Open Science, and how did you deal with them? (Practical, academic culture, technical, etc.)
 
-_Golnaz Taheri_: While the benefits of Open Science are clear, there are certainly challenges. One of the practical challenges
-I’ve faced is ensuring that my data and code are properly documented and organised so that they can be used by others. This can be
-time-consuming and requires discipline, especially when working with large, complex datasets. Moreover, it’s crucial to
-ensure that the data is shared ethically, with consideration for privacy and consent, so that it doesn't inadvertently
-harm individuals or communities.
+_Golnaz Taheri_: While the benefits of Open Science are clear, there are certainly challenges. One of the practical
+challenges I’ve faced is ensuring that my data and code are properly documented and organised so that they can be
+used by others. This can be time-consuming and requires discipline, especially when working with large, complex
+datasets. Moreover, it’s crucial to ensure that the data is shared ethically, with consideration for privacy and
+consent, so that it doesn't inadvertently harm individuals or communities.
 Another challenge is the academic culture, as some researchers may still hesitate to share their work openly due to
 concerns about intellectual property or the fear that others might misuse their data. To overcome this, I emphasise the
 importance of collaboration and transparency in my field. I also actively promote the idea that data sharing must be
@@ -127,7 +130,8 @@ intuitive and rewarding.
 
 ### What advice would you give to other researchers who want to make their science more open?
 
-_Golnaz Taheri_: Start small but make a commitment to being transparent and open. Share your data and code early in the process and
+_Golnaz Taheri_: Start small but make a commitment to being transparent and open.
+Share your data and code early in the process and
 follow the FAIR principles to ensure that your work is accessible and reusable. It’s also important to engage with
 platforms that support Open Science, such as GitHub for code, and utilize institutional resources like NBIS and Bianca
 for computational support. Finally, prioritize collaboration and ask for feedback from others; Open Science is not just
@@ -141,8 +145,9 @@ documentation can make a big difference in whether your work gets adopted more b
 
 ### How does SciLifeLab/DDLS Fellow program facilitate Open Science in your work?
 
-_Golnaz Taheri_: The SciLifeLab/DDLS Fellow program has been crucial in supporting Open Science in my work by providing access
-to invaluable resources like NBIS, Bianca, and Berzelius. These platforms allow me to manage, analyse, and share large
+_Golnaz Taheri_: The SciLifeLab/DDLS Fellow program has been crucial in supporting Open Science in my work by providing
+access to invaluable resources like NBIS, Bianca, and Berzelius.
+These platforms allow me to manage, analyse, and share large
 biological datasets efficiently, making my work more accessible to others. Furthermore, SciLifeLab’s Open Science
 culture, supported by Sweden’s strong open access policies, provides a robust infrastructure for data sharing and
 collaboration.

--- a/content/open_science/open_science_stories.md
+++ b/content/open_science/open_science_stories.md
@@ -6,12 +6,12 @@ menu:
     weight: 4
 ---
 
-# Open Science Stories 
+# Open Science Stories
 
 ## Golnaz Taheri and Gisele Miranda
 
 From code sharing to FAIR data, two of our new SciLifeLab/DDLS (Data Driven Life Sciences) Fellows discuss their Open
-Science journeys. They highlight practical steps, benefits, and challenges of making research more transparent and 
+Science journeys. They highlight practical steps, benefits, and challenges of making research more transparent and
 accessible. Their stories showcase how Open Science fuels collaboration and accelerates discovery.
 
 {{< image_pair 

--- a/content/open_science/resources.md
+++ b/content/open_science/resources.md
@@ -51,8 +51,8 @@ On 23 February 2024, SciLifeLab announced that it had joined [CoARA](https://coa
 (Coalition for Advancing Research
 Assessment) as a signatory member. This reaffirmed SciLifeLab’s commitment to advancing research assessment and open
 science practices.
-You can review SciLifeLab’s CoARA Action Plan
-[here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
+You can review SciLifeLab’s CoARA Action Plan in this
+[Google Docs document](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
 Note, [DORA](https://sfdora.org) (San Francisco Declaration on Research Assessment) laid
 the foundation for research assessment reform by advocating for qualitative evaluation over journal-based metrics,
 a principle that CoARA builds upon to drive systemic change through collective institutional commitment.
@@ -114,7 +114,7 @@ The [National Library of Sweden](https://www.kb.se/) (Kungliga Biblioteket) has 
 [National Guidelines on Open Science](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738), providing material for
 Swedish institutions and research funders in aligning policies, infrastructure, and coordination efforts with
 international recommendations. You can read The National Guidelines for Open Science
-[here](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738).
+in the [official PDF document](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738).
 
 ### The EU Open Science Policy
 
@@ -145,8 +145,8 @@ support Sweden’s transition towards open and FAIR research practices.
 
 [UNESCO](https://www.unesco.org/en) developed the [Open Science Toolkit](https://www.unesco.org/en/open-science/toolkit?hub=686),
 a collection of guides, policies, and factsheets designed to support the implementation of the
-[UNESCO Recommendation on Open Science](https://www.unesco.org/en/open-science/about?hub=686). You can review the UNESCO
-Open Science Toolkit [here](https://www.unesco.org/en/open-science/toolkit?hub=686).
+[UNESCO Recommendation on Open Science](https://www.unesco.org/en/open-science/about?hub=686).
+You can find more information on the [UNESCO Open Science Toolkit webpage](https://www.unesco.org/en/open-science/toolkit?hub=686).
 
 ### SUHF Roadmap for Open Science with Action Proposals for Implementation
 

--- a/content/open_science/resources.md
+++ b/content/open_science/resources.md
@@ -85,7 +85,7 @@ offers guidance on key topics, including data management plans, metadata, versio
 
 ## External Resources {.highlighted-header #external-resources}
 
-{{< logo_row 
+{{< logo_row
 "/img/open_science/resources/fair_aware.png|FAIR Aware logo"
 "/img/open_science/resources/eu_commission.png|EU Commission logo"
 "/img/open_science/resources/vetenskapsrådet.png|Vetenskapsrådet logo"

--- a/content/open_science/resources.md
+++ b/content/open_science/resources.md
@@ -21,58 +21,66 @@ Here, you’ll find a collection of resources designed to help you integrate
 
 ## SciLifeLab Resources {.highlighted-header #scilifelab-resources}
 
-#### SciLifeLab Open Science Onboarding
+### SciLifeLab Open Science Onboarding
 
-Here you can find our [Open Science Onboarding](https://doi.org/10.17044/scilifelab.29087126) which will guide you through the essential concepts to get you started on
-your open science journey.
+Here you can find our [Open Science Onboarding](https://doi.org/10.17044/scilifelab.29087126) which will guide you
+through the essential concepts to get you started on your open science journey.
 
-#### Open Science Checklists
+### Open Science Checklists
 
 The following checklists are available to provide practical guidance on steps you can take to incorporate open science
 and FAIR into your research workflows:
 
-- Open Access Checklist ([Markdown](https://github.com/ScilifelabDataCentre/open-science-checklists/blob/develop/open_access_checklist.md), [PDF](https://doi.org/10.17044/scilifelab.29086706.v1))
+- Open Access Checklist
+  ([Markdown](https://github.com/ScilifelabDataCentre/open-science-checklists/blob/develop/open_access_checklist.md),
+  [PDF](https://doi.org/10.17044/scilifelab.29086706.v1))
 - Open Data Guidelines ([RDM Guidelines](https://data-guidelines.scilifelab.se/))
-- Open Science Software Checklist ([Markdown](https://github.com/ScilifelabDataCentre/open-science-checklists/blob/develop/open_software_checklist.md), [PDF](https://doi.org/10.17044/scilifelab.29086775.v1))
+- Open Science Software Checklist
+  ([Markdown](https://github.com/ScilifelabDataCentre/open-science-checklists/blob/develop/open_software_checklist.md),
+  [PDF](https://doi.org/10.17044/scilifelab.29086775.v1))
 - [FAIR-Aware Self Assessment Tool](https://fairaware.dans.knaw.nl/)
 
-#### CoARA Action Plan for SciLifeLab
+### CoARA Action Plan for SciLifeLab
 
-{{< image_float 
-  image="/img/open_science/resources/coara.png" 
+{{< image_float
+  image="/img/open_science/resources/coara.png"
   alt="COARA logo"
 >}}
 
-On 23 February 2024, SciLifeLab announced that it had joined [CoARA](https://coara.eu/) (Coalition for Advancing Research
+On 23 February 2024, SciLifeLab announced that it had joined [CoARA](https://coara.eu/)
+(Coalition for Advancing Research
 Assessment) as a signatory member. This reaffirmed SciLifeLab’s commitment to advancing research assessment and open
 science practices.
-You can review SciLifeLab’s CoARA Action Plan [here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
+You can review SciLifeLab’s CoARA Action Plan
+[here](https://docs.google.com/document/d/1KAKOK6HoXsixQA5FaPegDIw1w3uI6OvlHgT2YR1m0pg/edit?tab=t.0).
 Note, [DORA](https://sfdora.org) (San Francisco Declaration on Research Assessment) laid
 the foundation for research assessment reform by advocating for qualitative evaluation over journal-based metrics,
 a principle that CoARA builds upon to drive systemic change through collective institutional commitment.
 
 {{< /image_float  >}}
 
-#### SciLifeLab Data Policy
+### SciLifeLab Data Policy
 
 The [SciLifeLab Data Policy](https://www.scilifelab.se/wp-content/uploads/2023/10/Data-Policy.pdf) outlines SciLifeLab's
 commitment to Open Science, research transparency, and the FAIR
 principles, ensuring that data from publicly funded research is as open as possible, while adhering to legal and
-ethical requirements. It sets expectations for SciLifeLab-affiliated programs, infrastructure, and researchers to promote
+ethical requirements.
+It sets expectations for SciLifeLab-affiliated programs, infrastructure, and researchers to promote
 data sharing, reproducibility, and accessibility, while providing the necessary resources, support, and governance to
 integrate these principles into the research we produce.
 
-#### SciLifeLab Training Hub
+### SciLifeLab Training Hub
 
 The [SciLifeLab Training Hub](https://www.scilifelab.se/training/) offers a range of educational opportunities and
 training infrastructure, to advance Open Science and FAIR learning, ensuring Sweden’s life science community has open
-access to world-class knowledge and expertise. View [SciLifeLab Training Hub’s website](https://www.scilifelab.se/training/)
+access to world-class knowledge and expertise. View
+[SciLifeLab Training Hub’s website](https://www.scilifelab.se/training/)
 to learn more about training tools, upcoming courses and ways in which the Training Hub team can support you.
 
-#### SciLifeLab RDM Guidelines
+### SciLifeLab RDM Guidelines
 
-{{< image_float 
-  image="/img/open_science/resources/rdm_guidelines.png" 
+{{< image_float
+  image="/img/open_science/resources/rdm_guidelines.png"
   alt="RDM Guidelines logo"
 >}}
 
@@ -93,14 +101,14 @@ offers guidance on key topics, including data management plans, metadata, versio
 "/img/open_science/resources/plan_s.png|Plan-S logo"
 >}}
 
-#### FAIR-Aware Self Assessment Tool
+### FAIR-Aware Self Assessment Tool
 
 The [FAIR-Aware Self Assessment Tool](https://fairaware.dans.knaw.nl/) helps researchers evaluate their knowledge of the
 FAIR principles, offering guidance to enhance the findability, accessibility, interoperability, and reusability of their
 data. In addition, the [F-UJI FAIR assessment tool](https://www.f-uji.net/) is an automated tool designed to evaluate
 the FAIRness of research data objects.
 
-#### The National Guidelines for Open Science
+### The National Guidelines for Open Science
 
 The [National Library of Sweden](https://www.kb.se/) (Kungliga Biblioteket) has published
 [National Guidelines on Open Science](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738), providing material for
@@ -108,16 +116,18 @@ Swedish institutions and research funders in aligning policies, infrastructure, 
 international recommendations. You can read The National Guidelines for Open Science
 [here](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738).
 
-#### The EU Open Science Policy
+### The EU Open Science Policy
 
 The [EU Open Science Policy](https://research-and-innovation.ec.europa.eu/strategy/strategy-research-and-innovation/our-digital-future/open-science_en)
 promotes openness, collaboration, and transparency in research by removing barriers, fostering data sharing, and
 enhancing scientific impact. This is achieved by advocating for practices like open access, reproducibility, and citizen
 engagement, and supporting these efforts with initiatives and infrastructures such as the
 [European Open Science Cloud (EOSC)](https://eosc.eu/eosc-about/) and [OpenAIRE](https://www.openaire.eu/).
-EOSC provides a federated infrastructure for sharing and accessing research data across Europe, while OpenAIRE supports open science by enabling open access to publications, linking research outputs, and facilitating compliance with EU open science policies.
+EOSC provides a federated infrastructure for sharing and accessing research data across Europe, while OpenAIRE supports
+open science by enabling open access to publications, linking research outputs,
+and facilitating compliance with EU open science policies.
 
-#### The Swedish Research Council: Vision and Guiding Principles
+### The Swedish Research Council: Vision and Guiding Principles
 
 The [Swedish Research Council](https://www.vr.se/) (Vetenskaprådet) produced a
 [Vision and Guiding Principles for Open Access to Research Data](https://www.vr.se/english/mandates/open-science/open-access-to-research-data/vision-and-guiding-principles.html).
@@ -131,21 +141,21 @@ found on the [Swedish Research Council’s Open Science webpage](https://www.vr.
 This platform serves as a central resource for national guidelines, ongoing projects, and collaborative efforts that
 support Sweden’s transition towards open and FAIR research practices.
 
-#### UNESCO Open Science Toolkit
+### UNESCO Open Science Toolkit
 
 [UNESCO](https://www.unesco.org/en) developed the [Open Science Toolkit](https://www.unesco.org/en/open-science/toolkit?hub=686),
 a collection of guides, policies, and factsheets designed to support the implementation of the
 [UNESCO Recommendation on Open Science](https://www.unesco.org/en/open-science/about?hub=686). You can review the UNESCO
 Open Science Toolkit [here](https://www.unesco.org/en/open-science/toolkit?hub=686).
 
-#### SUHF Roadmap for Open Science with Action Proposals for Implementation
+### SUHF Roadmap for Open Science with Action Proposals for Implementation
 
 The [roadmap](https://suhf.se/app/uploads/2025/02/REC-2021-1-Open-Science-Roadmap-REVISED-31-01-2025.pdf) includes
 overarching recommendations that clarify the responsibilities of higher education institutions, as well as proposals for
 measures and capabilities that need to be established at these institutions during the transition to a responsible,
 secure, and open scientific system.
 
-#### Plan S/Coalition S
+### Plan S/Coalition S
 
 [Plan S](https://www.coalition-s.org/) is a European initiative (with Swedish participation) that mandates full and
 immediate Open Access for publicly funded research. Essential for researchers navigating open publishing policies.

--- a/content/open_science/resources.md
+++ b/content/open_science/resources.md
@@ -21,12 +21,12 @@ Here, you’ll find a collection of resources designed to help you integrate
 
 ## SciLifeLab Resources {.highlighted-header #scilifelab-resources}
 
-### SciLifeLab Open Science Onboarding
+#### SciLifeLab Open Science Onboarding
 
 Here you can find our [Open Science Onboarding](https://doi.org/10.17044/scilifelab.29087126) which will guide you
 through the essential concepts to get you started on your open science journey.
 
-### Open Science Checklists
+#### Open Science Checklists
 
 The following checklists are available to provide practical guidance on steps you can take to incorporate open science
 and FAIR into your research workflows:
@@ -40,7 +40,7 @@ and FAIR into your research workflows:
   [PDF](https://doi.org/10.17044/scilifelab.29086775.v1))
 - [FAIR-Aware Self Assessment Tool](https://fairaware.dans.knaw.nl/)
 
-### CoARA Action Plan for SciLifeLab
+#### CoARA Action Plan for SciLifeLab
 
 {{< image_float
   image="/img/open_science/resources/coara.png"
@@ -59,7 +59,7 @@ a principle that CoARA builds upon to drive systemic change through collective i
 
 {{< /image_float  >}}
 
-### SciLifeLab Data Policy
+#### SciLifeLab Data Policy
 
 The [SciLifeLab Data Policy](https://www.scilifelab.se/wp-content/uploads/2023/10/Data-Policy.pdf) outlines SciLifeLab's
 commitment to Open Science, research transparency, and the FAIR
@@ -69,7 +69,7 @@ It sets expectations for SciLifeLab-affiliated programs, infrastructure, and res
 data sharing, reproducibility, and accessibility, while providing the necessary resources, support, and governance to
 integrate these principles into the research we produce.
 
-### SciLifeLab Training Hub
+#### SciLifeLab Training Hub
 
 The [SciLifeLab Training Hub](https://www.scilifelab.se/training/) offers a range of educational opportunities and
 training infrastructure, to advance Open Science and FAIR learning, ensuring Sweden’s life science community has open
@@ -77,7 +77,7 @@ access to world-class knowledge and expertise. View
 [SciLifeLab Training Hub’s website](https://www.scilifelab.se/training/)
 to learn more about training tools, upcoming courses and ways in which the Training Hub team can support you.
 
-### SciLifeLab RDM Guidelines
+#### SciLifeLab RDM Guidelines
 
 {{< image_float
   image="/img/open_science/resources/rdm_guidelines.png"
@@ -101,14 +101,14 @@ offers guidance on key topics, including data management plans, metadata, versio
 "/img/open_science/resources/plan_s.png|Plan-S logo"
 >}}
 
-### FAIR-Aware Self Assessment Tool
+#### FAIR-Aware Self Assessment Tool
 
 The [FAIR-Aware Self Assessment Tool](https://fairaware.dans.knaw.nl/) helps researchers evaluate their knowledge of the
 FAIR principles, offering guidance to enhance the findability, accessibility, interoperability, and reusability of their
 data. In addition, the [F-UJI FAIR assessment tool](https://www.f-uji.net/) is an automated tool designed to evaluate
 the FAIRness of research data objects.
 
-### The National Guidelines for Open Science
+#### The National Guidelines for Open Science
 
 The [National Library of Sweden](https://www.kb.se/) (Kungliga Biblioteket) has published
 [National Guidelines on Open Science](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738), providing material for
@@ -116,7 +116,7 @@ Swedish institutions and research funders in aligning policies, infrastructure, 
 international recommendations. You can read The National Guidelines for Open Science
 in the [official PDF document](https://urn.kb.se/resolve?urn=urn:nbn:se:kb:publ-738).
 
-### The EU Open Science Policy
+#### The EU Open Science Policy
 
 The [EU Open Science Policy](https://research-and-innovation.ec.europa.eu/strategy/strategy-research-and-innovation/our-digital-future/open-science_en)
 promotes openness, collaboration, and transparency in research by removing barriers, fostering data sharing, and
@@ -127,7 +127,7 @@ EOSC provides a federated infrastructure for sharing and accessing research data
 open science by enabling open access to publications, linking research outputs,
 and facilitating compliance with EU open science policies.
 
-### The Swedish Research Council: Vision and Guiding Principles
+#### The Swedish Research Council: Vision and Guiding Principles
 
 The [Swedish Research Council](https://www.vr.se/) (Vetenskaprådet) produced a
 [Vision and Guiding Principles for Open Access to Research Data](https://www.vr.se/english/mandates/open-science/open-access-to-research-data/vision-and-guiding-principles.html).
@@ -141,21 +141,21 @@ found on the [Swedish Research Council’s Open Science webpage](https://www.vr.
 This platform serves as a central resource for national guidelines, ongoing projects, and collaborative efforts that
 support Sweden’s transition towards open and FAIR research practices.
 
-### UNESCO Open Science Toolkit
+#### UNESCO Open Science Toolkit
 
 [UNESCO](https://www.unesco.org/en) developed the [Open Science Toolkit](https://www.unesco.org/en/open-science/toolkit?hub=686),
 a collection of guides, policies, and factsheets designed to support the implementation of the
 [UNESCO Recommendation on Open Science](https://www.unesco.org/en/open-science/about?hub=686).
 You can find more information on the [UNESCO Open Science Toolkit webpage](https://www.unesco.org/en/open-science/toolkit?hub=686).
 
-### SUHF Roadmap for Open Science with Action Proposals for Implementation
+#### SUHF Roadmap for Open Science with Action Proposals for Implementation
 
 The [roadmap](https://suhf.se/app/uploads/2025/02/REC-2021-1-Open-Science-Roadmap-REVISED-31-01-2025.pdf) includes
 overarching recommendations that clarify the responsibilities of higher education institutions, as well as proposals for
 measures and capabilities that need to be established at these institutions during the transition to a responsible,
 secure, and open scientific system.
 
-### Plan S/Coalition S
+#### Plan S/Coalition S
 
 [Plan S](https://www.coalition-s.org/) is a European initiative (with Swedish participation) that mandates full and
 immediate Open Access for publicly funded research. Essential for researchers navigating open publishing policies.

--- a/content/open_science/who_we_are.md
+++ b/content/open_science/who_we_are.md
@@ -6,8 +6,7 @@ menu:
     weight: 2
 ---
 
-
-# Who We Are 
+# Who We Are
 
 {{< image_text_row
   image="/img/open_science/team_photo.png"


### PR DESCRIPTION
### Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR fixes markdownlint errors in Open Science content to align with formatting standards. As part of PR #383 ([FREYA-1232](https://scilifelab.atlassian.net/browse/FREYA-1232))
 
### Changes Made
<!-- One-liners or bullet points -->

- Removed trailing spaces and added final newlines
-  Updated Config file (.github/.markdownlint-cli2.yaml) to 
    - Allow multiple H1 (  MD025 set to false)
    - Allow internal links (  MD051 set to false)
    - Allow lines up to 180 characters, to fit links and longer titles


### Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->

For Freya: Check if you agree with the updates to the config file. 
For the open science team: To comply with hyperlink formatting I had to rephrase, so you mainly need to check if commit https://github.com/ScilifelabDataCentre/data.scilifelab.se/pull/407/commits/a7cb5daf47b7ea3ba125bdb4e2d0d4f98fd5d502 looks good.
 
### Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

