### PR TITLE
Update mixed up captions on who we are page

### DIFF
--- a/content/open_science/who_we_are.md
+++ b/content/open_science/who_we_are.md
@@ -30,10 +30,10 @@ making every team member within SciLifeLab a part of our broader Open Science ef
 {{< image_pair 
   image1="/img/open_science/res_software_funders_2024.png"
   alt1="Group photo of Research Software Funders Workshop 2024"
-  caption1="SciLifeLab Team members at the 2024 DDLS Conference" 
+  caption1="Group photo of 2024 International Research Software Funders Workshop" 
   image2="/img/open_science/ddls_conference_2024.png" 
   alt2="Group photo of DDLS Conference 2024"
-  caption2="Open Science Team at the 2024 DDLS Conference" 
+  caption2="SciLifeLab Team members at the 2024 DDLS Conference" 
 >}}
 
 You can view our broader team from the [Data Centre](https://www.scilifelab.se/contact/data-center/) and find out more


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR fixes incorrect captions on the Who We Are page.
Would be great to include this in the upcoming release (#410). It might also introduce additional conflicts to those resolved in #411

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
Open Science team added to confirm the captions are now correct
Team FREYA added as reviewers to confirm merging into develop won't cause issues with their pending changes
 
### ✅ Checklist
- [ ] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [ ] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
