### PR TITLE
FREYA - 1230: Add events and announcements page for Open Science

### DIFF
--- a/content/news/2025-05-14.md
+++ b/content/news/2025-05-14.md
@@ -4,6 +4,7 @@ date: 2025-05-14
 thumbnail: "/img/news/CoP_webinar_20250414.png"
 caption: "Representation of the Community of Practice Webinar."
 show_thumbnail_on_page: True
+open_science: True
 images: ["/img/news/CoP_webinar_20250414.png"]
 ---
 

--- a/content/news/2025-05-15.md
+++ b/content/news/2025-05-15.md
@@ -4,6 +4,7 @@ date: 2025-05-15
 thumbnail: "/img/news/desci_webinar_2025_05_15.png"
 caption: "Representation of DeSci Webinar"
 show_thumbnail_on_page: True
+open_science: True
 images: ["/img/news/desci_webinar_2025_05_15.png"]
 ---
 The Open Science Team hosted a webinar in collaboration with DeSci Publish, where we explored how researchers can curate, link, and share

--- a/content/news/2025-05-20.md
+++ b/content/news/2025-05-20.md
@@ -4,6 +4,7 @@ date: 2025-05-20
 thumbnail: "/img/news/open_science_team.jpg"
 caption: "SciLifeLab Open Science team"
 show_thumbnail_on_page: True
+open_science: True
 images: ["/img/news/open_science_team.jpg"]
 ---
 

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -7,23 +7,26 @@ menu:
 show_section_nav: true
 back_to_top_button: true
 ---
+
 # Events & Updates
+
 This page lists upcoming conferences, webinars, workshops, training sessions, and other relevant events for researchers in data-driven life
 science with an interest in Open Science. It includes activities organised by SciLifeLab, as well as selected events hosted by external
-Open Science organisations. 
+Open Science organisations.
 
 All times are given in Central European Time (CET/CEST). Questions about individual events should be directed to the organisers of that
 event.
 
 ## SciLifeLab Events
+
 This section displays events related to Open Science, organised by SciLifeLab.
 <section id="sll-events-section" class="my-4">
   <!-- The events content will be filled by shortcode 'update_activities' that is called below -->
 </section>
 
 ## Other Events
-This section features upcoming Open Science events hosted by external organisations that are relevant to the Swedish research community.
 
+This section features upcoming Open Science events hosted by external organisations that are relevant to the Swedish research community.
 
 <!--change link to the actual template -->
 If you know of an appropriate event that is not listed here, please send the information provided in
@@ -36,6 +39,7 @@ with ‘Open Science’ in the subject line.
 </section>
 
 ## Announcements
+
 This section highlights news and announcements related to Open Science from SciLifeLab.
 <!-- This page have more dunamic content, so everything is written in a shortcode -->
 {{< update_activities >}}

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -28,11 +28,7 @@ This section displays events related to Open Science, organised by SciLifeLab.
 
 This section features upcoming Open Science events hosted by external organisations that are relevant to the Swedish research community.
 
-<!--change link to the actual template -->
-If you know of an appropriate event that is not listed here, please send the information provided in
-[this template](https://github.com/ScilifelabDataCentre/data.scilifelab.se/blob/open-science-activity-page/data/open_science/events.json)
-to  [datacenter@scilifelab.se](mailto:datacentre@scilifelab.se?subject=Open%20Science)
-with ‘Open Science’ in the subject line.
+If you know of an appropriate event that is not listed here, fill in the template provided (with relevant fields) in the [Events & Training section of contribution guide](https://github.com/ScilifelabDataCentre/data.scilifelab.se/blob/develop/CONTRIBUTING.md#events--training) with the event details and email this to [datacentre@scilifelab.se](mailto:datacentre@scilifelab.se?subject=Open%20Science) with ‘Open Science’ in the subject line.
 
 <section id="other-events-section" class="my-4">
   <!-- The events content will be filled by shortcode 'update_activities' that is called below -->

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -41,5 +41,5 @@ with ‘Open Science’ in the subject line.
 ## Announcements
 
 This section highlights news and announcements related to Open Science from SciLifeLab.
-<!-- This page have more dunamic content, so everything is written in a shortcode -->
+<!-- This page have more dynamic content, so everything is written in a shortcode -->
 {{< update_activities >}}

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -28,7 +28,10 @@ This section displays events related to Open Science, organised by SciLifeLab.
 
 This section features upcoming Open Science events hosted by external organisations that are relevant to the Swedish research community.
 
-If you know of an appropriate event that is not listed here, fill in the template provided (with relevant fields) in the [Events & Training section of contribution guide](https://github.com/ScilifelabDataCentre/data.scilifelab.se/blob/develop/CONTRIBUTING.md#events--training) with the event details and email this to [datacentre@scilifelab.se](mailto:datacentre@scilifelab.se?subject=Open%20Science) with ‘Open Science’ in the subject line.
+If you know of an appropriate event that is not listed here, fill in the template provided (with relevant fields) in the
+[Events & Training section of contribution guide](https://github.com/ScilifelabDataCentre/data.scilifelab.se/blob/develop/CONTRIBUTING.md#events--training)
+with the event details and email this to [datacentre@scilifelab.se](mailto:datacentre@scilifelab.se?subject=Open%20Science)
+with 'Open Science' in the subject line.
 
 <section id="other-events-section" class="my-4">
   <!-- The events content will be filled by shortcode 'update_activities' that is called below -->

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -7,20 +7,35 @@ menu:
 show_section_nav: true
 back_to_top_button: true
 ---
+# Events & Updates
+This page lists upcoming conferences, webinars, workshops, training sessions, and other relevant events for researchers in data-driven life
+science with an interest in Open Science. It includes activities organised by SciLifeLab, as well as selected events hosted by external
+Open Science organisations. 
 
-## Scilifelab events
+All times are given in Central European Time (CET/CEST). Questions about individual events should be directed to the organisers of that
+event.
 
+## SciLifeLab Events
+This section displays events related to Open Science, organised by SciLifeLab.
 <section id="sll-events-section" class="my-4">
   <!-- The events content will be filled by shortcode 'update_activities' that is called below -->
 </section>
 
-## Other events
+## Other Events
+This section features upcoming Open Science events hosted by external organisations that are relevant to the Swedish research community.
+
+
+<!--change link to the actual template -->
+If you know of an appropriate event that is not listed here, please send the information provided in
+[this template](https://github.com/ScilifelabDataCentre/data.scilifelab.se/blob/open-science-activity-page/data/open_science/events.json)
+to  [datacenter@scilifelab.se](mailto:datacentre@scilifelab.se?subject=Open%20Science)
+with ‘Open Science’ in the subject line.
 
 <section id="other-events-section" class="my-4">
   <!-- The events content will be filled by shortcode 'update_activities' that is called below -->
 </section>
 
 ## Announcements
-
+This section highlights news and announcements related to Open Science from SciLifeLab.
 <!-- This page have more dunamic content, so everything is written in a shortcode -->
 {{< update_activities >}}

--- a/content/open_science/activities.md
+++ b/content/open_science/activities.md
@@ -1,0 +1,26 @@
+---
+title: "Events and Updates"
+menu:
+  open_science:
+    name: "Events & Updates"
+    weight: 6
+show_section_nav: true
+back_to_top_button: true
+---
+
+## Scilifelab events
+
+<section id="sll-events-section" class="my-4">
+  <!-- The events content will be filled by shortcode 'update_activities' that is called below -->
+</section>
+
+## Other events
+
+<section id="other-events-section" class="my-4">
+  <!-- The events content will be filled by shortcode 'update_activities' that is called below -->
+</section>
+
+## Announcements
+
+<!-- This page have more dunamic content, so everything is written in a shortcode -->
+{{< update_activities >}}

--- a/content/open_science/contact_us.md
+++ b/content/open_science/contact_us.md
@@ -3,7 +3,7 @@ title: "Contact us"
 menu:
   open_science:
     name: "Contact us"
-    weight: 6
+    weight: 7
 ---
 
 

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -59,7 +59,7 @@
             "venue": "Sankt Augustin, Germany",
             "organisers": "",
             "event_url": "https://froscon.org/en/cfp/",
-            "description": "A community event featuring talks and workshops on free and open source software, digital sovereignty, AI, and related technologies."
+            "description": "A community event featuring talks and workshops on free and open source software, digital sovereignty, artificial intelligence, and related technologies."
         },
         {
             "title": "IFLA World Library and Information Congress",
@@ -131,7 +131,7 @@
             "venue": "Brisbane, Australia",
             "organisers": "",
             "event_url": "https://www.rd-alliance.org/event/international-data-week-2025-brisbane-australia/",
-            "description": "A global event uniting data professionals, researchers, and policymakers to explore how data can drive positive societal change, with a focus on ethical governance, open science, and inclusive innovation."
+            "description": "A global event uniting data professionals, researchers and policymakers to explore how data can drive positive societal change, with a focus on ethical governance, open science, and inclusive innovation."
         },
         {
             "title": "European Open Science Cloud (EOSC) Symposium 2025",
@@ -143,7 +143,7 @@
             "venue": "Brussels, Belgium",
             "organisers": "",
             "event_url": "https://eosc.eu/events/eosc-symposium-2025/",
-            "description": "An event for the European Open Science community, dedicated to advancing the EOSC Federation through strategic collaboration, shared infrastructure, and real-world scientific use cases."
+            "description": "An event for the European Open Science community, dedicated to advancing the EOSC Federation through strategic collaboration, shared infrastructure and real-world scientific use cases."
         },
         {
             "title": "LU Open Science Days 2025",
@@ -155,7 +155,7 @@
             "venue": "Lund, Sweden",
             "organisers": "",
             "event_url": "https://www.staff.lu.se/calendar/welcome-lu-open-science-days-2025",
-            "description": "A two-day event at Lund University exploring how open science can foster trust, transparency, and accountability in research, featuring discussions on topics like reproducibility, preprints, and indigenous knowledge. This lunch-to-lunch event, held at Palaestra in Lund, Sweden, is open to Lund University-affiliated researchers, PhD students, and support staff, with limited spots for external participants."
+            "description": "A two-day event at Lund University exploring how open science can foster trust, transparency and accountability in research, featuring discussions on topics like reproducibility, preprints, and indigenous knowledge. This lunch-to-lunch event, held at Palaestra in Lund, Sweden, is open to Lund University-affiliated researchers, PhD students and support staff, with limited spots for external participants."
         }
 
 

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -1,17 +1,6 @@
 {
     "items": [
-        {
-            "title": "Open science test event",
-            "type": "Event",
-            "date_start": "2025-08-12",
-            "time_start": "10:30",
-            "date_end": "2025-08-12",
-            "time_end": "13:30",
-            "venue": "Scilifelab Uppsala",
-            "organisers": "Scilifelab Data Centre",
-            "event_url": "https://www.scilifelab.se/events",
-            "description": "If you are working on an Open Science project or event at SciLifeLab and would like to showcase your work, please contact us via email at datacentre@scilifelab.se with the subject line ‘Open Science’."
-        },
+       
         {
             "title": "Metascience Conference",
             "type": "Event",

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -11,6 +11,128 @@
             "organisers": "Scilifelab Data Centre",
             "event_url": "https://www.scilifelab.se/events",
             "description": "If you are working on an Open Science project or event at SciLifeLab and would like to showcase your work, please contact us via email at datacentre@scilifelab.se with the subject line ‘Open Science’."
+        },
+        {
+            "title": "Metascience Conference",
+            "type": "Event",
+            "date_start": "2025-06-30",
+            "time_start": "",
+            "date_end": "2025-07-02",
+            "time_end": "",
+            "venue": "London, UK",
+            "organisers": "",
+            "event_url": "https://metascience.info/",
+            "description": "A global gathering for knowledge sharing, community building, and opportunities to define a roadmap of research and intervention priorities to accelerate science.  (Description taken from event website)"
+        },
+        {
+            "title": "LIBER 2025",
+            "type": "Event",
+            "date_start": "2025-07-02",
+            "time_start": "",
+            "date_end": "2025-07-04",
+            "time_end": "",
+            "venue": "Lausanne, Switzerland",
+            "organisers": "",
+            "event_url": "https://liberconference.eu/",
+            "description": "A leading forum for research library professionals to explore how libraries can drive innovation, foster collaboration, and address global challenges through open science, equitable access, and sustainable development."
+        },
+         {
+            "title": "Open Science: Monitoring Progress, Assessing Impact",
+            "type": "Event",
+            "date_start": "2025-07-07",
+            "time_start": "",
+            "date_end": "2025-07-08",
+            "time_end": "",
+            "venue": "Paris, France",
+            "organisers": "",
+            "event_url": "https://indico.un.org/event/1016293/",
+            "description": "A global gathering of open science stakeholders to share evidence, refine monitoring tools, and advance collaborative strategies for assessing the impact of open science initiatives."
+        },
+         {
+            "title": "Bioinformatics Open Source Conference (BOSC) 2025",
+            "type": "Event",
+            "date_start": "2025-07-21",
+            "time_start": "",
+            "date_end": "2025-07-22",
+            "time_end": "",
+            "venue": "Liverpool, UK",
+            "organisers": "",
+            "event_url": "https://www.open-bio.org/events/bosc-2025/",
+            "description": "A community-focused conference exploring open source bioinformatics, featuring sessions on open data, reproducibility, and data sustainability, along with interdisciplinary collaboration."
+        },
+        {
+            "title": "Free and Open Source Software Conference (FrOSCon)",
+            "type": "Event",
+            "date_start": "2025-08-16",
+            "time_start": "",
+            "date_end": "2025-08-17",
+            "time_end": "",
+            "venue": "Sankt Augustin, Germany",
+            "organisers": "",
+            "event_url": "https://froscon.org/en/cfp/",
+            "description": "A community-driven conference showcasing the latest in free and open source software, with talks and workshops on digital sovereignty, AI, open science, and emerging tech trends."
+        },
+        {
+            "title": "IFLA World Library and Information Congress",
+            "type": "Event",
+            "date_start": "2025-08-18",
+            "time_start": "",
+            "date_end": "2025-08-22",
+            "time_end": "",
+            "venue": "Astana, Kazakhstan",
+            "organisers": "",
+            "event_url": "https://2025.ifla.org/",
+            "description": "An international conference for library and information professionals, focusing on advancing equitable access to knowledge, fostering innovation, and building sustainable futures through global collaboration."
+        },
+        {
+            "title": "Conference on Research Data Infrastructure (CoRDI)",
+            "type": "Event",
+            "date_start": "2025-08-26",
+            "time_start": "",
+            "date_end": "2025-08-28",
+            "time_end": "",
+            "venue": "Aachen, Germany",
+            "organisers": "",
+            "event_url": "https://www.nfdi.de/cordi-2025/",
+            "description": "A conference highlighting innovations in research data management, featuring sessions on data literacy, infrastructure, and the societal impact of effective data practices."
+        },
+         {
+            "title": "STI-ENID 2025 – 29th Annual International Conference on Science and Technology Indicators",
+            "type": "Event",
+            "date_start": "2025-09-03",
+            "time_start": "",
+            "date_end": "2025-09-05",
+            "time_end": "",
+            "venue": "Bristol, UK",
+            "organisers": "",
+            "event_url": "https://www.stienid2025.org/",
+            "description": "A forum for research library professionals to explore how libraries can drive innovation, foster collaboration, and address global challenges through open science, equitable access, and sustainable development."
+        },
+         {
+            "title": "Open Science Fair",
+            "type": "Event",
+            "date_start": "2025-09-15",
+            "time_start": "",
+            "date_end": "2025-09-17",
+            "time_end": "",
+            "venue": "Geneva, Switzerland",
+            "organisers": "",
+            "event_url": "https://opensciencefair.eu/",
+            "description": "A collaborative forum uniting global open science communities to explore inclusive partnerships, innovative infrastructures, and policies that drive transparent and equitable research practices."
+        },
+         {
+            "title": "Open Science and AI Conference 2025",
+            "type": "Event",
+            "date_start": "2025-10-08",
+            "time_start": "",
+            "date_end": "2025-10-09",
+            "time_end": "",
+            "venue": "Hamburg, Germany",
+            "organisers": "",
+            "event_url": "https://www.open-science-conference.eu/",
+            "description": "A global forum for open science stakeholders to explore the intersection of open science and artificial intelligence, addressing challenges and opportunities in transparency, reproducibility, and responsible research practices."
         }
+
+
     ]
 }

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -131,6 +131,30 @@
             "organisers": "",
             "event_url": "https://www.open-science-conference.eu/",
             "description": "A global forum for open science stakeholders to explore the intersection of open science and artificial intelligence, addressing challenges and opportunities in transparency, reproducibility, and responsible research practices."
+        },
+        {
+            "title": "International Data Week and Research Data Alliance",
+            "type": "Event",
+            "date_start": "2025-10-13",
+            "time_start": "",
+            "date_end": "2025-10-16",
+            "time_end": "",
+            "venue": "Brisbane, Australia",
+            "organisers": "",
+            "event_url": "https://www.rd-alliance.org/event/international-data-week-2025-brisbane-australia/",
+            "description": "A global event uniting data professionals, researchers, and policymakers to explore how data can drive positive societal change, with a focus on ethical governance, open science, and inclusive innovation."
+        },
+        {
+            "title": "European Open Science Cloud (EOSC) Symposium 2025",
+            "type": "Event",
+            "date_start": "2025-11-03",
+            "time_start": "",
+            "date_end": "2025-11-05",
+            "time_end": "",
+            "venue": "Brussels, Belgium",
+            "organisers": "",
+            "event_url": "https://eosc.eu/events/eosc-symposium-2025/",
+            "description": "An event for the European Open Science community, dedicated to advancing the EOSC Federation through strategic collaboration, shared infrastructure, and real-world scientific use cases."
         }
 
 

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -11,7 +11,7 @@
             "venue": "London, UK",
             "organisers": "",
             "event_url": "https://metascience.info/",
-            "description": "A global gathering for knowledge sharing, community building, and opportunities to define a roadmap of research and intervention priorities to accelerate science.  (Description taken from event website)"
+            "description": "A meeting focused on collaboration, knowledge sharing, and shaping future directions for research and metascience."
         },
         {
             "title": "LIBER 2025",
@@ -23,7 +23,7 @@
             "venue": "Lausanne, Switzerland",
             "organisers": "",
             "event_url": "https://liberconference.eu/",
-            "description": "A leading forum for research library professionals to explore how libraries can drive innovation, foster collaboration, and address global challenges through open science, equitable access, and sustainable development."
+            "description": "A gathering for research library professionals to discuss innovation, access to knowledge, and development through open science and collaboration."
         },
          {
             "title": "Open Science: Monitoring Progress, Assessing Impact",
@@ -35,7 +35,7 @@
             "venue": "Paris, France",
             "organisers": "",
             "event_url": "https://indico.un.org/event/1016293/",
-            "description": "A global gathering of open science stakeholders to share evidence, refine monitoring tools, and advance collaborative strategies for assessing the impact of open science initiatives."
+            "description": "A global event bringing together open science stakeholders to exchange evidence, refine indicators, and discuss progress on implementation."
         },
          {
             "title": "Bioinformatics Open Source Conference (BOSC) 2025",
@@ -47,7 +47,7 @@
             "venue": "Liverpool, UK",
             "organisers": "",
             "event_url": "https://www.open-bio.org/events/bosc-2025/",
-            "description": "A community-focused conference exploring open source bioinformatics, featuring sessions on open data, reproducibility, and data sustainability, along with interdisciplinary collaboration."
+            "description": "A conference on open source bioinformatics, with sessions on open data, reproducibility, and sustainable scientific practices."
         },
         {
             "title": "Free and Open Source Software Conference (FrOSCon)",
@@ -59,7 +59,7 @@
             "venue": "Sankt Augustin, Germany",
             "organisers": "",
             "event_url": "https://froscon.org/en/cfp/",
-            "description": "A community-driven conference showcasing the latest in free and open source software, with talks and workshops on digital sovereignty, AI, open science, and emerging tech trends."
+            "description": "A community event featuring talks and workshops on free and open source software, digital sovereignty, AI, and related technologies."
         },
         {
             "title": "IFLA World Library and Information Congress",
@@ -95,7 +95,7 @@
             "venue": "Bristol, UK",
             "organisers": "",
             "event_url": "https://www.stienid2025.org/",
-            "description": "A forum for research library professionals to explore how libraries can drive innovation, foster collaboration, and address global challenges through open science, equitable access, and sustainable development."
+            "description": "A conference for research library professionals to explore how libraries can drive innovation, foster collaboration, and address global challenges through open science, equitable access, and sustainable development."
         },
          {
             "title": "Open Science Fair",
@@ -107,10 +107,10 @@
             "venue": "Geneva, Switzerland",
             "organisers": "",
             "event_url": "https://opensciencefair.eu/",
-            "description": "A collaborative forum uniting global open science communities to explore inclusive partnerships, innovative infrastructures, and policies that drive transparent and equitable research practices."
+            "description": "An event uniting global open science communities to explore inclusive partnerships, innovative infrastructures, and policies that drive transparent and equitable research practices."
         },
          {
-            "title": "Open Science and AI Conference 2025",
+            "title": "Open Science Conference 2025",
             "type": "Event",
             "date_start": "2025-10-08",
             "time_start": "",
@@ -119,7 +119,7 @@
             "venue": "Hamburg, Germany",
             "organisers": "",
             "event_url": "https://www.open-science-conference.eu/",
-            "description": "A global forum for open science stakeholders to explore the intersection of open science and artificial intelligence, addressing challenges and opportunities in transparency, reproducibility, and responsible research practices."
+            "description": "A global gathering for open science stakeholders to explore the intersection of open science and artificial intelligence, addressing challenges and opportunities in transparency, reproducibility, and responsible research practices."
         },
         {
             "title": "International Data Week and Research Data Alliance",
@@ -144,7 +144,20 @@
             "organisers": "",
             "event_url": "https://eosc.eu/events/eosc-symposium-2025/",
             "description": "An event for the European Open Science community, dedicated to advancing the EOSC Federation through strategic collaboration, shared infrastructure, and real-world scientific use cases."
+        },
+        {
+            "title": "LU Open Science Days 2025",
+            "type": "Event",
+            "date_start": "2025-11-19",
+            "time_start": "",
+            "date_end": "2025-11-20",
+            "time_end": "",
+            "venue": "Lund, Sweden",
+            "organisers": "",
+            "event_url": "https://www.staff.lu.se/calendar/welcome-lu-open-science-days-2025",
+            "description": "A two-day event at Lund University exploring how open science can foster trust, transparency, and accountability in research, featuring discussions on topics like reproducibility, preprints, and indigenous knowledge. This lunch-to-lunch event, held at Palaestra in Lund, Sweden, is open to Lund University-affiliated researchers, PhD students, and support staff, with limited spots for external participants."
         }
+
 
 
     ]

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -1,0 +1,16 @@
+{
+    "items": [
+        {
+            "title": "Open science test event",
+            "type": "Event",
+            "date_start": "2025-08-12",
+            "time_start": "10:30",
+            "date_end": "2025-08-12",
+            "time_end": "13:30",
+            "venue": "Scilifelab Uppsala",
+            "organisers": "Scilifelab Data Centre",
+            "event_url": "https://www.scilifelab.se/events",
+            "description": "If you are working on an Open Science project or event at SciLifeLab and would like to showcase your work, please contact us via email at datacentre@scilifelab.se with the subject line ‘Open Science’."
+        }
+    ]
+}

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -3,9 +3,9 @@
         {
             "title": "Open science test event",
             "type": "Event",
-            "date_start": "2025-08-12",
+            "date_start": "2025-06-12",
             "time_start": "10:30",
-            "date_end": "2025-08-12",
+            "date_end": "2025-06-12",
             "time_end": "13:30",
             "venue": "Scilifelab Uppsala",
             "organisers": "Scilifelab Data Centre",

--- a/layouts/shortcodes/update_activities.html
+++ b/layouts/shortcodes/update_activities.html
@@ -213,7 +213,7 @@
 
     // Call the function to display other events
     getDataFromUrl(
-      decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fdevelop%2Fdata%2Fopen_science%2Fevents.json"),
+      decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fopen-science-activity-page%2Fdata%2Fopen_science%2Fevents.json"),
       addEvents,
       "other-events-section" // "div id" in open_science/activites page
     );

--- a/layouts/shortcodes/update_activities.html
+++ b/layouts/shortcodes/update_activities.html
@@ -1,0 +1,222 @@
+<!-- This shortcode consists of code to populate events and news in open_science/activites page -->
+
+<section class="my-4">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 g-lg-4">
+        {{ $news := where .Site.RegularPages "Section" "eq" "news" }}
+        {{ $os_news := where $news "Params.open_science" "eq" true }}
+        {{ range $os_news }}
+        <div class="col">
+            <div class="news-card moving-card">
+                <div aria-hidden="true">
+                    <a href="{{ .RelPermalink }}">
+                        <img class="img-fluid" src="{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ "/img/news/scilifelab.jpg" }}{{ end }}"
+                            alt="news-{{ .Date }}">
+                    </a>
+                </div>
+                <div class="px-3 py-2" style="background-color: #045c64; color: #fff;"> {{ .Date | time.Format ":date_long" }} </div>
+                <div class="px-3 pb-1">
+                    <h5 class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+                </div>
+            </div>
+        </div>
+        {{ end }}
+      </div>
+</section>
+
+<!-- JS script to load events -->
+ <script>
+  // Functions need to be run when the DOM is ready
+  document.addEventListener("DOMContentLoaded", function (event) {
+
+    // Takes a URL and calls the callback function pass the data fetched
+    function getDataFromUrl(url, load_callback, context) {
+      let req = new XMLHttpRequest();
+      req.overrideMimeType("application/json");
+      req.open("GET", url, true);
+      // The function call for fetching data and display
+      req.onload = function () {
+        load_callback(JSON.parse(req.responseText).items, context);
+      };
+      req.send(null);
+    }; // function "getDataFromUrl" ends here
+
+    // Take data about events and displays it
+    function addEvents(dataArray, context) {
+      let eventList = [];
+      dataArray.forEach((event) => {
+        // Show only events that are meant to be displayed
+        if (context == "sll-events-section" && typeof event.category !== 'undefined' &&
+           !event.category.includes("Open Science")) {
+          return;
+        };
+        // Not insterested if the deadline have already passed
+        event.banner_date = event.date_start || event.registration_deadline;
+        if (typeof event.banner_date !== 'undefined'){
+          let dateString = event.banner_date + (event.time_start ? ' ' + event.time_start : '');
+          let [h, m] = event.time_start ? event.time_start.split(":") : [0, 0];
+          if (new Date(dateString) >= new Date().setHours(h, m)){
+            eventList.push(event);
+          };
+        };
+      }); // dataArray for each ends here
+      eventList = eventList.sort((a,b) => (a.banner_date > b.banner_date) ? 1 : (a.banner_date < b.banner_date) ? -1 : 0);
+      let eventsHTML;
+      // If no event to show, display appropriate message
+      if (eventList.length === 0) {
+        eventsHTML = `<div class="alert alert-secondary mt-4">
+                          There are currently no events to display, but upcoming events will be posted here.
+                        </div>`;
+      } else {
+        eventsHTML = `<div class="row g-2" id="${context}-container">`;
+        eventList.forEach((event, ind) => {
+            let event_date = new Date(event.banner_date);
+            eventsHTML += `<div class="col-md-6 col-lg-4 event">
+                            <div class="card-box moving-card">
+                            <div class="d-flex justify-content-between">
+                                <div>
+                                <span class="badge event-type mb-1">${event.type}</span>
+                                <h5><a class="" role="button" data-bs-toggle="modal"
+                                    data-bs-target="#descriptionModal${ind}">${event.title}</a></h5>
+                                </div>
+                                <div>
+                                <div class="px-2 pb-1 m-2 d-flex flex-column rounded event-date">
+                                <div class="px-2 fs-3 mx-auto">${event_date.getDate()}</div>
+                                <div class="pb-1 px-2 mx-auto">${event_date.toLocaleString('default', {'month': 'long'})}</div>
+                                </div>
+                                </div>
+                            </div>`;
+            let event_date_time = [], date_format_options = {'month': 'short', day:'numeric', year: 'numeric'};
+            event.date_start && event_date_time.push(new Date(event.date_start).toLocaleString('en-US', date_format_options));
+            event.time_start && event_date_time.push(event.time_start);
+            (event.date_end || event.time_end) && event_date_time.push("-")
+            event.date_end && event_date_time.push(new Date(event.date_end).toLocaleString('en-US', date_format_options));
+            event.time_end && event_date_time.push(event.time_end);
+            if (event_date_time.length > 0){
+                eventsHTML += `<div class="row mt-3">
+                                <div class="col">
+                                <b>Date and time:</b> ${event_date_time.join(" ")}
+                                </div>
+                            </div>`;
+            }
+            if (event.registration_deadline){
+                eventsHTML += `<div class="row mt-1">
+                                <div class="col">
+                                <b>Registration deadline:</b> ${new Date(event.registration_deadline).toLocaleString('en-US', date_format_options)}
+                                </div>
+                            </div>`;
+            }
+            if (event.organisers){
+                eventsHTML += `<div class="row">
+                                <div class="col">
+                                <b>Organiser(s):</b> ${event.organisers}
+                                </div>
+                            </div>`;
+            }
+            if (event.venue){
+                eventsHTML += `<div class="row">
+                                <div class="col">
+                                <b>Venue:</b> ${event.venue}
+                                </div>
+                            </div>`;
+            }
+            eventsHTML += `<div class="row mt-3">
+                            <div class="col">
+                                <button type="button" class="btn btn-details btn-sm" data-bs-toggle="modal"
+                                data-bs-target="#descriptionModal-${context}-${ind}">
+                                See details
+                                </button>
+                                <div class="modal fade" id="descriptionModal-${context}-${ind}" tabindex="-1"
+                                aria-labelledby="descriptionModalLabel-${context}-${ind}">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title" id="descriptionModalLabel-${context}-${ind}">${event.title}</h5>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <div class="row">
+                                        <div class="col">
+                                            <b>Event type:</b> <span class="badge event-type mb-1">${event.type}</span>
+                                        </div>
+                                        </div>`;
+            if (event_date_time.length > 0){
+                eventsHTML += `<div class="row mt-1">
+                                <div class="col">
+                                <b>Date and time:</b> ${event_date_time.join(" ")}
+                                </div>
+                            </div>`;
+            }
+            if (event.registration_deadline){
+                eventsHTML += `<div class="row mt-1">
+                                <div class="col">
+                                <b>Registration deadline:</b> ${new Date(event.registration_deadline).toLocaleString('en-US', date_format_options)}
+                                </div>
+                            </div>`;
+            }
+            if (event.organisers){
+                eventsHTML += `<div class="row mt-1">
+                                <div class="col">
+                                <b>Organiser(s):</b> ${event.organisers}
+                                </div>
+                            </div>`;
+            }
+            if (event.venue){
+                eventsHTML += `<div class="row mt-1">
+                                <div class="col">
+                                <b>Venue:</b> ${event.venue}
+                                </div>
+                            </div>`;
+            }
+            if (event.description){
+                eventsHTML += `<div class="row mt-3">
+                                <div class="col">
+                                <b>Description:</b><br> ${event.description}
+                                </div>
+                            </div>`;
+            }
+            eventsHTML += `<div class="row mt-3">
+                            <p>For more information, see the event webpage at the link below.</p>
+                            <div class="col-md">
+                                <a target="_blank" href="${event.event_url}"><i class="bi bi-globe"></i> Event webpage</a>
+                            </div>`;
+            if (event.registration_url){
+                eventsHTML += `<div class="col-md">
+                                <a target="_blank" href="${event.registration_url}"><i class="bi bi-globe"></i>
+                                Registration</a>
+                            </div>`;
+            }
+            eventsHTML += `</div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        </div>
+                        </div>
+                    </div>
+                    </div>
+                </div>
+                </div>
+            </div>
+            </div>`;
+        }); // for each events iteration to create html cards ends here
+        eventsHTML += `</div>`;
+      };
+      let eventsSection = document.getElementById(context);
+      eventsSection.innerHTML = eventsHTML;
+    } // function "addEvents" ends here
+
+    // Call the function to display SLL events
+    getDataFromUrl(
+      decodeURIComponent("https%3A%2F%2Fblobserver.dc.scilifelab.se%2Fblob%2Fddls_events.json"),
+      addEvents,
+      "sll-events-section" // "div id" in open_science/activites page
+    );
+
+    // Call the function to display other events
+    getDataFromUrl(
+      decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fdevelop%2Fdata%2Fopen_science%2Fevents.json"),
+      addEvents,
+      "other-events-section" // "div id" in open_science/activites page
+    );
+
+  }); // Document "DOMContentLoaded" trigger ends here
+</script>

--- a/layouts/shortcodes/update_activities.html
+++ b/layouts/shortcodes/update_activities.html
@@ -213,7 +213,7 @@
 
     // Call the function to display other events
     getDataFromUrl(
-      decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fopen-science-activity-page%2Fdata%2Fopen_science%2Fevents.json"),
+      decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fdevelop%2Fdata%2Fopen_science%2Fevents.json"),
       addEvents,
       "other-events-section" // "div id" in open_science/activites page
     );


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR creates a new page in Open Science section to show events and announcements
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added new `activities.md` content file
- Added new `shortcode` to handle dynamic stuff
- Added new front matter parameter on open science news items
- Added new `JSON` file for external events
- Populated `JSON` file  for external events
- Added captions for each section in the open science activities section 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [ ] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
Closes: [FREYA-1230](https://scilifelab.atlassian.net/browse/FREYA-1230)
