### PR TITLE
FREYA-1455: Integrate service and data source

### DIFF
--- a/content/resources/data_sources.md
+++ b/content/resources/data_sources.md
@@ -1,6 +1,7 @@
 ---
 title: Data sources for data-driven life science
 layout: data_source
+back_to_top_button: true
 ---
 
 This is a list of data sources available for data-driven life science in Sweden. Use the **Search** function to find sources by name/keywords (often more granular than other filters). A resource type of **Repository** indicates that at least some users can both submit and access data, whilst **Data Source** indicates that data can only be accessed, not submitted. It is also possible to filter data sources according to **Data Type** and **Scientific Area**.

--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -12,6 +12,7 @@ menu:
     name: Services
     identifier: services
     weight: 10
+back_to_top_button: true
 ---
 
 This page details the services available for **researchers** and **data-producing facilities**. We define services as tools, databases, and support functions (e.g. hosting services) useful in data-driven life science. Use the search function to identify services that may be relevant for you.

--- a/data/data_sources.json
+++ b/data/data_sources.json
@@ -1,1550 +1,2393 @@
 [
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics", "Epidemiology and Biology of Infection"],
-    "search_tags": [
-      "InParanoiDB",
-      "ortholog groups",
-      "orthologs",
-      "proteins",
-      "protein domains",
-      "complex co-membership",
-      "eukaryotic",
-      "eukaryote",
-      "Sonnhammer laboratory"
+    "type": [
+      "Data source"
     ],
-    "name": "InParanoiDB",
-    "description": "A database of orthologs between 640 species, including inparalogs for both protein domains and full-length proteins.",
-    "thumbnail": "/img/data_sources_thumbs/inparanoidb.png",
-    "url": "https://inparanoidb.sbc.su.se",
-    "data":["Proteins and proteomes", "Genes and genomes"],
-    "disease_type": [ 
-      "Various diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": [
-      "OrthoDisease",
-      "ortholog",
-      "orthologs",
-      "Disease orthologs",
-      "Human disease",
-      "gene",
-      "Ensembl gene identifiers",
-      "OMIM",
-      "Online Mendelian Inheritance in Man",
-      "Sonnhammer laboratory"
+    "ddls": [
+      "Precision Medicine and Diagnostics"
     ],
-    "name": "OrthoDisease",
-    "description": "A database of human disease orthologs.",
-    "thumbnail": "/img/data_sources_thumbs/orthodisease.png",
-    "url": "https://orthodisease.sbc.su.se/cgi-bin/index.cgi",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Various diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
     "search_tags": [
-      "ELIXIR Core Data Resource", "SCAPIS database", "Swedish CArdioPulmonary bioImage Study", "cardiovascular disease", "CVD", "chronic obstructive pulmonary disease", "COPD", "registry data", "health registers"
+      "ELIXIR Core Data Resource",
+      "SCAPIS database",
+      "Swedish CArdioPulmonary bioImage Study",
+      "cardiovascular disease",
+      "CVD",
+      "chronic obstructive pulmonary disease",
+      "COPD",
+      "registry data",
+      "health registers"
     ],
     "name": "SCAPIS database",
     "description": "Data from over 30k patients from across Sweden to study cardiovascular disease (CVD) and chronic obstructive pulmonary disease (COPD). Biobanked blood and DNA analysed in collaboration with SciLifeLab.",
     "thumbnail": "/img/data_sources_thumbs/SCAPIS.png",
     "url": "https://www.scapis.org/",
-    "data":["Imaging", "Chemical biology", "Clinical", "Genes and genomes", "Biobank"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cardiovascular Diseases"
-    ]
+    "data": [
+      "Imaging",
+      "Chemical biology",
+      "Clinical",
+      "Genes and genomes",
+      "Biobank"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics", "Evolution and Biodiversity"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics",
+      "Evolution and Biodiversity"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Sveriges Dataportal", "Sweden’s national data portal", "national data portal", "data portal", "DIGG", "myndigheten for digital förvaltning", "environment", "economy", "finance", "education", "culture", "sport", "regions", "government", "public sector", "energy", "legal system", "health", "population", "society", "agriculture", "fisheries", "forestry", "food", "transport"
+      "ELIXIR Core Data Resource",
+      "Sveriges Dataportal",
+      "Sweden’s national data portal",
+      "national data portal",
+      "data portal",
+      "DIGG",
+      "myndigheten for digital förvaltning",
+      "environment",
+      "economy",
+      "finance",
+      "education",
+      "culture",
+      "sport",
+      "regions",
+      "government",
+      "public sector",
+      "energy",
+      "legal system",
+      "health",
+      "population",
+      "society",
+      "agriculture",
+      "fisheries",
+      "forestry",
+      "food",
+      "transport"
     ],
     "name": "Sveriges Dataportal",
     "description": "Organisations can share and download data related to data-driven development and innovation. It is created by Myndigheten for Digital Förvaltning (DIGG). Multiple types of data are available.",
     "thumbnail": "/img/data_sources_thumbs/Sveriges_dp.png",
     "url": "https://www.dataportal.se/",
-    "data":["General"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Public Health", 
-      "Various Diseases"
-    ]
+    "data": [
+      "General"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "VEuPathDB", "Eukaryotic Pathogen", "Vector and Host Informatics Resource", "National Institute of Allergy and Infectious Diseases",  "NIAID", "Wellcome Trust", "eukaryotic pathogens", "invertebrate vectors", "disease", "vectors", "pathogens", "genomic", "genetic", "gene", "infectious disease", "kinetoplastida", "fungal", "fungus"
+      "ELIXIR Core Data Resource",
+      "VEuPathDB",
+      "Eukaryotic Pathogen",
+      "Vector and Host Informatics Resource",
+      "National Institute of Allergy and Infectious Diseases",
+      "NIAID",
+      "Wellcome Trust",
+      "eukaryotic pathogens",
+      "invertebrate vectors",
+      "disease",
+      "vectors",
+      "pathogens",
+      "genomic",
+      "genetic",
+      "gene",
+      "infectious disease",
+      "kinetoplastida",
+      "fungal",
+      "fungus"
     ],
     "name": "VEuPathoDB",
     "description": "Aggregation of data from multiple genomic and other large datasets related to eukaryotic pathogens and invertebrate disease vectors. Includes data on many emerging and re-emerging infectious disease.",
     "thumbnail": "/img/data_sources_thumbs/veupathdb.jpg",
     "url": "https://veupathdb.org/veupathdb/app",
-    "data":["Genes and genomes", "Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Swiss-model", "protein modelling", "protein structure", "homology modelling", "protein homology modelling", "Deepview", "sequences", "protein sequences", "model species", "lDDT", "QS-Score", "TM-Score", "RMSD", "DockQ", "alphafolddb"
+      "ELIXIR Core Data Resource",
+      "Swiss-model",
+      "protein modelling",
+      "protein structure",
+      "homology modelling",
+      "protein homology modelling",
+      "Deepview",
+      "sequences",
+      "protein sequences",
+      "model species",
+      "lDDT",
+      "QS-Score",
+      "TM-Score",
+      "RMSD",
+      "DockQ",
+      "alphafolddb"
     ],
     "name": "SWISS-MODEL",
     "description": "An automated protein structure homology server. Protein sequences for 13 core species are modelled weekly. The aim of this database is to make protein modelling is accessible to researchers worldwide.",
     "thumbnail": "/img/data_sources_thumbs/swiss-model.png",
     "url": "https://swissmodel.expasy.org/",
-    "data":["Proteins and proteomes", "Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "string", "protein interactions", "protein-protein interactions", "direct associations", "indirect associations", "functional associations", "physical associations", "genomic context predictions", "predictions", "high-throughput experiments", "high throughput lab experiments"
+      "ELIXIR Core Data Resource",
+      "string",
+      "protein interactions",
+      "protein-protein interactions",
+      "direct associations",
+      "indirect associations",
+      "functional associations",
+      "physical associations",
+      "genomic context predictions",
+      "predictions",
+      "high-throughput experiments",
+      "high throughput lab experiments"
     ],
     "name": "STRING",
     "description": "Database of known and predicted protein-protein interactions, including both direct and indirect associations. Data is aggregated from multiple sources, e.g. existing databases and computer modelling.",
     "thumbnail": "/img/data_sources_thumbs/string.png",
     "url": "https://string-db.org/",
-    "data":["Proteins and proteomes", "Molecular and cellular structures", "Enzymes, pathways, interactions"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Molecular and cellular structures",
+      "Enzymes, pathways, interactions"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Silva", "small subunit", "large subunit", "rRNA", "ribosomal RNA", "sequence data", "ARB", "bacteria", "archea", "eukarya"
+      "ELIXIR Core Data Resource",
+      "Silva",
+      "small subunit",
+      "large subunit",
+      "rRNA",
+      "ribosomal RNA",
+      "sequence data",
+      "ARB",
+      "bacteria",
+      "archea",
+      "eukarya"
     ],
     "name": "SILVA",
     "description": "A comprehensive online resource for quality-checked ribosomal RNA (rRNA) data. Includes aligned small and large subunits of rRNA from all three domains of life (archea, bacteria, eukarya).",
     "thumbnail": "/img/data_sources_thumbs/silva.png",
     "url": "https://www.arb-silva.de/",
-    "data":["Genes and genomes", "Evolution and phylogeny"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases", 
-      "Public Health", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Evolution and phylogeny"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Rhea", "curated database", "chemical reactions", "transport reactions", "enzyme annotation", "transporter annotation", "UniProtKB", "ChEMBI", "Chemical Entities of Biological Interests"
+      "ELIXIR Core Data Resource",
+      "Rhea",
+      "curated database",
+      "chemical reactions",
+      "transport reactions",
+      "enzyme annotation",
+      "transporter annotation",
+      "UniProtKB",
+      "ChEMBI",
+      "Chemical Entities of Biological Interests"
     ],
     "name": "Rhea",
     "description": "A knowledge base of chemical and transport reactions of biological interest curated by experts. It is the standard for enzyme and transporter annotation in UniProtKB.",
     "thumbnail": "/img/data_sources_thumbs/rhea.png",
     "url": "https://www.rhea-db.org/",
-    "data":["Chemical biology", "Enzymes, pathways, interactions"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Chemical biology",
+      "Enzymes, pathways, interactions"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "pombase", "registry data", "fission yeast", "Schizosaccharomyces pombe", "structural annotation", "functional annotation", "literature curation", "large-scale datasets", "global core data source", "model organism"
+      "ELIXIR Core Data Resource",
+      "pombase",
+      "registry data",
+      "fission yeast",
+      "Schizosaccharomyces pombe",
+      "structural annotation",
+      "functional annotation",
+      "literature curation",
+      "large-scale datasets",
+      "global core data source",
+      "model organism"
     ],
     "name": "PomBase",
     "description": "A knowledge base for the model organism Schizosaccharomyces pombe, which is a fission yeast. It enables exploration of genetic, phenotypic, and molecular data from multiple sources.",
     "thumbnail": "/img/data_sources_thumbs/pombase.png",
     "url": "https://www.pombase.org/about",
-    "data":["Genes and genomes", "Phenotypic", "Proteins and proteomes", "Evolution and phylogeny"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Genes and genomes",
+      "Phenotypic",
+      "Proteins and proteomes",
+      "Evolution and phylogeny"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "orphadata science", "global biodata coalition", "rare diseases", "orphan drugs", "orphaned nomenclature of rare diseases", "orphaned scientific knowledge base"
+      "ELIXIR Core Data Resource",
+      "orphadata science",
+      "global biodata coalition",
+      "rare diseases",
+      "orphan drugs",
+      "orphaned nomenclature of rare diseases",
+      "orphaned scientific knowledge base"
     ],
     "name": "Orphadata Science",
     "description": "Provides access to high-quality datasets related to rare diseases and orphan drugs. The data is available in a reusable and computable format.",
     "thumbnail": "/img/data_sources_thumbs/orphadata.png",
     "url": "https://www.orphadata.com/orphadata-science/",
-    "data":["Genes and genomes", "Clinical", "Phenotypic", "Biobank"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Rare Diseases"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Clinical",
+      "Phenotypic",
+      "Biobank"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "MGnify", "microbiome-derived nucleic acid sequences", "assembly", "sequence analysis", "taxonomic assignments", "functional annotations", "metabarcoding", "metatranscriptiomic", "metagenomic datasets", "microbiome data"
+      "ELIXIR Core Data Resource",
+      "MGnify",
+      "microbiome-derived nucleic acid sequences",
+      "assembly",
+      "sequence analysis",
+      "taxonomic assignments",
+      "functional annotations",
+      "metabarcoding",
+      "metatranscriptiomic",
+      "metagenomic datasets",
+      "microbiome data"
     ],
     "name": "MGnify",
     "description": "Facilitates the assembly, analysis, and archiving of microbiome-derived nucleic acid sequences. Provides taxonomic assignments and functional annotations covering multiple data types from many environments.",
     "thumbnail": "/img/data_sources_thumbs/mgnify.png",
     "url": "https://www.ebi.ac.uk/metagenomics",
-    "data":["Molecular and cellular structures","Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Molecular and cellular structures",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Interpro", "functional protein sequences", "protein", "sequences", "protein families", "predict domain", "functional analysis", "molecular", "FASTA"
+      "ELIXIR Core Data Resource",
+      "Interpro",
+      "functional protein sequences",
+      "protein",
+      "sequences",
+      "protein families",
+      "predict domain",
+      "functional analysis",
+      "molecular",
+      "FASTA"
     ],
     "name": "InterPro",
     "description": "A collation of protein data from multiple sources. It enables the functional analysis of proteins by classifying them into families, and also allows for the prediction of domains and important sites.",
     "thumbnail": "/img/data_sources_thumbs/interpro.jpg",
     "url": "https://www.ebi.ac.uk/interpro/",
-    "data":["Molecular and cellular structures", "Proteins and proteomes"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Molecular and cellular structures",
+      "Proteins and proteomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Molecular interaction database", "MINT", "molecular interaction", "interaction", "protein-protein interactions", "data mining", "imex consortium", "protein coding genes"
+      "ELIXIR Core Data Resource",
+      "Molecular interaction database",
+      "MINT",
+      "molecular interaction",
+      "interaction",
+      "protein-protein interactions",
+      "data mining",
+      "imex consortium",
+      "protein coding genes"
     ],
     "name": "Molecular Interaction Database",
     "description": "A public, open source database detailing protein-protein interactions that are experimentally verified. The interactions have been mined from scientific literature by expert curators.",
     "thumbnail": "/img/data_sources_thumbs/mint.png",
     "url": "https://mint.bio.uniroma2.it",
-    "data":["Enzymes, pathways, interactions", "Proteins and proteomes","Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Enzymes, pathways, interactions",
+      "Proteins and proteomes",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "HUGO Gene Nomenclature Committee", "HGNC", "nomenclature", "genome", "human genomes", "human loci", "protein coding genes", "ncRNA genes", "ncRNA pseudogenes"
+      "ELIXIR Core Data Resource",
+      "HUGO Gene Nomenclature Committee",
+      "HGNC",
+      "nomenclature",
+      "genome",
+      "human genomes",
+      "human loci",
+      "protein coding genes",
+      "ncRNA genes",
+      "ncRNA pseudogenes"
     ],
     "name": "HUGO Gene Nomenclature Committee",
     "description": "A resource for approved human gene nomenclature. It is responsible for approving unique symbols and names for human loci. It contains thousands of gene symbols and names, and many gene families and sets.",
     "thumbnail": "/img/data_sources_thumbs/hgnc.jpeg",
     "url": "https://www.genenames.org/",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Evolution and Biodiversity", "Epidemiology and Biology of Infection"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Evolution and Biodiversity",
+      "Epidemiology and Biology of Infection"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Ensembl", "Ensembl Genomes", "invertebrate genome", "genomics", "sequence variation", "evolution", "genome browser", "plant", "microbes", "protists", "metazoa", "fungi", "bacteria"
+      "ELIXIR Core Data Resource",
+      "Ensembl",
+      "Ensembl Genomes",
+      "invertebrate genome",
+      "genomics",
+      "sequence variation",
+      "evolution",
+      "genome browser",
+      "plant",
+      "microbes",
+      "protists",
+      "metazoa",
+      "fungi",
+      "bacteria"
     ],
     "name": "Ensembl Genomes",
     "description": "A browser for invertebrate genomes that enables comparative analysis, data mining, and visualisation. Information is available for viruses, metazoa, protists, plants, fungi, and bacteria.",
     "thumbnail": "/img/data_sources_thumbs/ensembl.png",
     "url": "http://ensemblgenomes.org/",
-    "data":["Evolution and phylogeny", "Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Evolution and phylogeny",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Ensembl", "vertebrate genome", "genomics", "sequence variation", "evolution", "genome browser", "BLAST", "BLAT", "DNA", "Protein sequence"
+      "ELIXIR Core Data Resource",
+      "Ensembl",
+      "vertebrate genome",
+      "genomics",
+      "sequence variation",
+      "evolution",
+      "genome browser",
+      "BLAST",
+      "BLAT",
+      "DNA",
+      "Protein sequence"
     ],
     "name": "Ensembl",
     "description": "A browser for vertebrate genomes. Supports research in evolution, transcriptional regulation, and sequence variation. It is part of the Ensembl project, which also includes Ensembl Genomes.",
     "thumbnail": "/img/data_sources_thumbs/ensembl.png",
     "url": "http://www.ensembl.org/index.html",
-    "data":["Evolution and phylogeny", "Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Developmental Disorders", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Evolution and phylogeny",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "chemical entities of biological interest", "ChEBI", "small chemical compounds", "molecular entities", "isotope"
+      "ELIXIR Core Data Resource",
+      "chemical entities of biological interest",
+      "ChEBI",
+      "small chemical compounds",
+      "molecular entities",
+      "isotope"
     ],
     "name": "Chemical Entities of Biological Interest",
     "description": "A dictionary of molecular entities (i.e. constitutionally or isotopically distinct atoms, molecules, ions, ion pairs, radicals, etc.). It is focused in particular on small chemical compounds.",
     "thumbnail": "/img/data_sources_thumbs/chembi.png",
     "url": "https://www.ebi.ac.uk/chebi/",
-    "data":["Chemical biology", "Molecular and cellular structures"],
-    "disease_type": []
+    "data": [
+      "Chemical biology",
+      "Molecular and cellular structures"
+    ]
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "cellosaurus", "cell lines", "biomedical research"
+      "ELIXIR Core Data Resource",
+      "cellosaurus",
+      "cell lines",
+      "biomedical research"
     ],
     "name": "Cellosaurus",
     "description": "A knowledge resource aiming to describe all cell lines used in biomedical research. Users can browse the cell lines by group.",
     "thumbnail": "/img/data_sources_thumbs/cellosaurus.png",
     "url": "https://www.cellosaurus.org/",
-    "data":["Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Neurological Disorders", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Gene3D", "CATH", "protein", "hierarchical domain classification", "PDB", "Protein Data Bank", "Alphafold", "3D structure", "protein function"
+      "ELIXIR Core Data Resource",
+      "Gene3D",
+      "CATH",
+      "protein",
+      "hierarchical domain classification",
+      "PDB",
+      "Protein Data Bank",
+      "Alphafold",
+      "3D structure",
+      "protein function"
     ],
     "name": "CATH/Gene3D",
     "description": "A database containing information on evolutionary relationships between protein domains. It classifies protein domains from Protein Data Bank in a hierarchical manner.",
     "thumbnail": "/img/data_sources_thumbs/CATH.png",
     "url": "http://www.cathdb.info/",
-    "data":["Molecular and cellular structures", "Proteins and proteomes", "Evolution and phylogeny"],
-    "disease_type": []
+    "data": [
+      "Molecular and cellular structures",
+      "Proteins and proteomes",
+      "Evolution and phylogeny"
+    ]
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "BRENDA", "enzyme", "enzyme-ligand", "metabolism", "taxonomy", "publication mining", "genome", "genetic"
+      "ELIXIR Core Data Resource",
+      "BRENDA",
+      "enzyme",
+      "enzyme-ligand",
+      "metabolism",
+      "taxonomy",
+      "publication mining",
+      "genome",
+      "genetic"
     ],
     "name": "BRENDA",
     "description": "A database containing information about enzymes and enzyme-ligands from all taxonomic groups. Data is extracted from primary literature, and integrated with external data and prediction algorithms.",
     "thumbnail": "/img/data_sources_thumbs/BRENDA.png",
     "url": "http://www.brenda-enzymes.org/",
-    "data":["Enzymes, pathways, interactions", "Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Enzymes, pathways, interactions",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Evolution and Biodiversity"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Evolution and Biodiversity"
+    ],
     "search_tags": [
-      "ELIXIR Core Data Resource", "Bacdive", "bacterial", "bacteria", "diversity", "taxonomy", "morphology", "physiology", "origin", "distribution", "bacterial strains", "strain"
+      "ELIXIR Core Data Resource",
+      "Bacdive",
+      "bacterial",
+      "bacteria",
+      "diversity",
+      "taxonomy",
+      "morphology",
+      "physiology",
+      "origin",
+      "distribution",
+      "bacterial strains",
+      "strain"
     ],
     "name": "BacDive",
     "description": "The largest database for standardised bacterial phenotypic data. It includes >600 data fields, e.g. taxonomy, molecular data, and morphology. Integrates data from many sources & makes it freely accessible.",
     "thumbnail": "/img/data_sources_thumbs/bacdive.png",
     "url": "https://bacdive.dsmz.de/",
-    "data":["Genes and genomes", "Molecular and cellular structures", "Phenotypic"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Genes and genomes",
+      "Molecular and cellular structures",
+      "Phenotypic"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "Protein Data Bank", "PDB", "Protein Data Bank Europe", "PDBe", "structure", "biochemistry", "proteomic", "nucleic acids", "assemblies", "alpha fold", "model archive", "computational models", "3D structure", "biochemistry", "ELIXIR Deposition Database", "ELIXIR Core Data Resource"
+      "Protein Data Bank",
+      "PDB",
+      "Protein Data Bank Europe",
+      "PDBe",
+      "structure",
+      "biochemistry",
+      "proteomic",
+      "nucleic acids",
+      "assemblies",
+      "alpha fold",
+      "model archive",
+      "computational models",
+      "3D structure",
+      "biochemistry",
+      "ELIXIR Deposition Database",
+      "ELIXIR Core Data Resource"
     ],
     "name": "Protein Data Bank Europe",
     "description": "A repository in which data on biological macromolecular structures can be deposited. A founding member of the worldwide Protein Data Bank (PDB), and works to collate, maintain, and provide access to PDB.",
     "thumbnail": "/img/data_sources_thumbs/PDBe.png",
     "url": "https://www.ebi.ac.uk/pdbe/about",
-    "data":["Proteins and proteomes", "Molecular and cellular structures", "Chemical biology"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Molecular and cellular structures",
+      "Chemical biology"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Deposition Database", "modelarchive", "models", "model", "macromolecular structure", "structures", "biomedical research", "PDB", "SIB", "protein", "alphafold"
+      "ELIXIR Deposition Database",
+      "modelarchive",
+      "models",
+      "model",
+      "macromolecular structure",
+      "structures",
+      "biomedical research",
+      "PDB",
+      "SIB",
+      "protein",
+      "alphafold"
     ],
     "name": "ModelArchive",
     "description": "Includes theoretical models of macromolecular structure, together with information about model coordinates, and details about assumptions, parameters, and constraints applied to simulations.",
     "thumbnail": "/img/data_sources_thumbs/modelarchive.png",
     "url": "https://www.modelarchive.org/",
-    "data":["Proteins and proteomes", "Molecular and cellular structures", "Chemical biology"],
-    "disease_type": []
+    "data": [
+      "Proteins and proteomes",
+      "Molecular and cellular structures",
+      "Chemical biology"
+    ]
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "ELIXIR Deposition Database", "metabolights", "metabolite", "spectra", "biological roles", "metabolics experiments"
+      "ELIXIR Deposition Database",
+      "metabolights",
+      "metabolite",
+      "spectra",
+      "biological roles",
+      "metabolics experiments"
     ],
     "name": "MetaboLights",
     "description": "Contains data from metabolics experiments, and derived information from them. It contains multiple types of data from many species and techniques. It and is the recommended repository for many journals.",
     "thumbnail": "/img/data_sources_thumbs/metabolights.png",
     "url": "https://www.ebi.ac.uk/metabolights/",
-    "data":["Chemical biology", "Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Chemical biology",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Cell and Molecular Biology"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "Lipid maps", "lipid metabolites and pathways strategy", "lipidomics", "steroid", "structure", "mass spectrometry", "bile acids", "plant steroid", "sterol", "ELIXIR Deposition Database", "tool", "ELIXIR Core Data Resource"
+      "Lipid maps",
+      "lipid metabolites and pathways strategy",
+      "lipidomics",
+      "steroid",
+      "structure",
+      "mass spectrometry",
+      "bile acids",
+      "plant steroid",
+      "sterol",
+      "ELIXIR Deposition Database",
+      "tool",
+      "ELIXIR Core Data Resource"
     ],
     "name": "LIPID MAPS",
     "description": "An open, systematic, and standardised resource for lipidomics research. It leads the field of lipid curation, classification, and nomenclature. It provides open access to multiple tools and data.",
     "thumbnail": "/img/data_sources_thumbs/lipid_maps.png",
     "url": "https://www.lipidmaps.org/",
-    "data":["Chemical biology", "Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Chemical biology",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "GWAS Catalog", "NHGRI-EBI Catalog of human genome-wide association studies", "genetics", "genome-wide association", "human", "EMBL-EBI", "NHGRI", "ELIXIR Deposition Database", "ELIXIR Core Data Resource"
+      "GWAS Catalog",
+      "NHGRI-EBI Catalog of human genome-wide association studies",
+      "genetics",
+      "genome-wide association",
+      "human",
+      "EMBL-EBI",
+      "NHGRI",
+      "ELIXIR Deposition Database",
+      "ELIXIR Core Data Resource"
     ],
     "name": "GWAS Catalog",
     "description": "The GWAS Catalog is a curated collection of human genome-wide association studies. It is results from a collaboration between EMBL-EBI and NHGRI.",
     "thumbnail": "/img/data_sources_thumbs/gwas.jpeg",
     "url": "https://www.ebi.ac.uk/gwas/",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology"
+    ],
     "search_tags": [
-      "Electron Microscopy Data Bank", "EMDB, cryogenic-sample", "Electron Microscopy volumes", "cryoEM", "tomograms", "macromolecular complexes", "subcellular structures", "ELIXIR Deposition Database", "ELIXIR Core Data Resource"
+      "Electron Microscopy Data Bank",
+      "EMDB, cryogenic-sample",
+      "Electron Microscopy volumes",
+      "cryoEM",
+      "tomograms",
+      "macromolecular complexes",
+      "subcellular structures",
+      "ELIXIR Deposition Database",
+      "ELIXIR Core Data Resource"
     ],
     "name": "Electron Microscopy Data Bank",
     "description": "A public repository for cryoEM and representative tomograms of macromolecular complexes and subcellular structures. Multiple different techniques are covered.",
     "thumbnail": "/img/data_sources_thumbs/EMDB.png",
     "url": "https://www.ebi.ac.uk/pdbe/emdb/",
-    "data":["Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "European Genome-phenome Archive", "EGA", "biomedical", "healthcare systems", "personally identifiable", "genetic", "clinical", "phenotypic", "ELIXIR Deposition Database", "ELIXIR Core Data Resource"
+      "European Genome-phenome Archive",
+      "EGA",
+      "biomedical",
+      "healthcare systems",
+      "personally identifiable",
+      "genetic",
+      "clinical",
+      "phenotypic",
+      "ELIXIR Deposition Database",
+      "ELIXIR Core Data Resource"
     ],
     "name": "European Genome-phenome Archive",
     "description": "A service for permanently archive and share personally identifiable genetic, phenotypic, and clinical data generated for biomedical research or for research-focused healthcare systems.",
     "thumbnail": "/img/data_sources_thumbs/ega.png",
     "url": "https://ega-archive.org/",
-    "data":["Genes and genomes", "Phenotypic", "Clinical"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Developmental Disorders",
-      "Psychiatric Disorders",
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Phenotypic",
+      "Clinical"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
     "search_tags": [
-      "biological studies", "embl-ebi", "supplementary information", "supporting data", "collections", "biostudies", "ELIXIR Deposition Database", "ELIXIR Core Data Resource"
+      "biological studies",
+      "embl-ebi",
+      "supplementary information",
+      "supporting data",
+      "collections",
+      "biostudies",
+      "ELIXIR Deposition Database",
+      "ELIXIR Core Data Resource"
     ],
     "name": "BioStudies",
     "description": "Includes descriptions of biological studies, and links data from them to other databases and data that does not fit in structured archives. Accepts a wide range of studies, and supplementary information.",
     "thumbnail": "/img/data_sources_thumbs/biostudies.png",
     "url": "https://www.ebi.ac.uk/biostudies/",
-    "data":["General"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Cardiovascular Diseases", 
-      "Metabolic Disorders"
-    ]
+    "data": [
+      "General"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection"
+    ],
     "search_tags": [
-      "mathematical models", "models", "biological systems", "biomedical systems", "mechanistic models", "physiology", "pharmaceutical", "literature", "publication", "bio models", "ELIXIR Deposition Database"
+      "mathematical models",
+      "models",
+      "biological systems",
+      "biomedical systems",
+      "mechanistic models",
+      "physiology",
+      "pharmaceutical",
+      "literature",
+      "publication",
+      "bio models",
+      "ELIXIR Deposition Database"
     ],
     "name": "BioModels",
     "description": "A repository of mathematical models related to biological and biomedical system. It contains many literature-based physiologically and pharmaceutically relevant mechanistic models.",
     "thumbnail": "/img/data_sources_thumbs/biomodels.png",
     "url": "http://www.ebi.ac.uk/biomodels/",
-    "data":["Enzymes, pathways, interactions"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Enzymes, pathways, interactions"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
-    "ddls": ["Epidemiology and Biology of Infection"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection"
+    ],
     "search_tags": [
-      "GISAID", "infectious", "disease", "influenza", "genetic sequence data", "clinical data", "epidemiological data", "emerging infectious diseases", "SARS-CoV-2", "COVID-19", "InfA", "InfB", "DNA"
+      "GISAID",
+      "infectious",
+      "disease",
+      "influenza",
+      "genetic sequence data",
+      "clinical data",
+      "epidemiological data",
+      "emerging infectious diseases",
+      "SARS-CoV-2",
+      "COVID-19",
+      "InfA",
+      "InfB",
+      "DNA"
     ],
     "name": "GISAID",
     "description": "A sequencing data repository on emerging infectious diseases, including influenza and SARS-CoV-2. Requires registration to access the data, and there are multiple conditions regarding data sharing.",
     "thumbnail": "/img/data_sources_thumbs/GISAID.jpg",
     "url": "https://www.gisaid.org/",
-    "data":["Genes and genomes", "Clinical", "Phenotypic"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Genes and genomes",
+      "Clinical",
+      "Phenotypic"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["repository"],
+    "type": [
+      "Repository"
+    ],
     "ddls": [
-      "Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
     ],
     "search_tags": [
-      "infectious", "disease", "influenza", "sequencing data", "emerging infectious diseases", "SARS-CoV-2", "COVID-19", "InfA", "InfB", "genetics", "genes", "nucleotides", "assemblies", "ENA", "human diseases", "human data", "WGS", "whole genome sequencing", "raw data", "coding", "non-coding", "RNA", "DNA", "RNA-seq", "transcriptome assembly", "genomic data", "European Nucleotide Archive", "ELIXIR Core Data Resource"
+      "infectious",
+      "disease",
+      "influenza",
+      "sequencing data",
+      "emerging infectious diseases",
+      "SARS-CoV-2",
+      "COVID-19",
+      "InfA",
+      "InfB",
+      "genetics",
+      "genes",
+      "nucleotides",
+      "assemblies",
+      "ENA",
+      "human diseases",
+      "human data",
+      "WGS",
+      "whole genome sequencing",
+      "raw data",
+      "coding",
+      "non-coding",
+      "RNA",
+      "DNA",
+      "RNA-seq",
+      "transcriptome assembly",
+      "genomic data",
+      "European Nucleotide Archive",
+      "ELIXIR Core Data Resource"
     ],
     "name": "European Nucleotide Archive",
     "description": "An open, global data resource for nucleotide sequences, including raw sequence data, alignments, and assemblies. The data is shared openly.",
     "url": "http://www.ebi.ac.uk/ena",
     "thumbnail": "/img/data_sources_thumbs/ENA.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection"],
-    "search_tags": ["infectious", "disease", "COVID-19", "code", "data", "SARS-CoV-2", "Sweden", "open data"],
-    "name": "Available code/data for COVID-19 from Sweden.",
-    "description": "Data and code shared in papers on COVID-19 that include at least one author affiliated with a Swedish research organisation.",
-    "url": "https://pathogens.se/datasets/all/",
-    "thumbnail": "/img/data_sources_thumbs/pathogens.png",
-    "data":["Genes and genomes","Proteins and proteomes","Molecular and cellular structures","Chemical biology","Evolution and phylogeny","Enzymes, pathways, interactions","Clinical","Phenotypic","Biobank","Imaging"],
-    "thumbnail_border": true,
-    "disease_type": []
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["infectious", "disease", "tuberculosis", "TB", "surveillance", "interactive databases", "European", "reports", "ECDC", "infographics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "infectious",
+      "disease",
+      "tuberculosis",
+      "TB",
+      "surveillance",
+      "interactive databases",
+      "European",
+      "reports",
+      "ECDC",
+      "infographics"
+    ],
     "name": "ECDC Tuberculosis",
     "description": "Contains open datasets related to tuberculosis, including an atlas showing the distribution of reported cases across Europe.",
     "url": "https://www.ecdc.europa.eu/en/tuberculosis/surveillance",
-    "data":["Clinical", "Phenotypic", "Epidemiology"],
+    "data": [
+      "Clinical",
+      "Phenotypic",
+      "Epidemiology"
+    ],
     "thumbnail": "/img/data_sources_thumbs/ecdc.png",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["infectious", "disease", "influenza", "avian influenza", "zoonotic", "zoonoses", "surveillance", "European", "reports", "ECDC"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "infectious",
+      "disease",
+      "influenza",
+      "avian influenza",
+      "zoonotic",
+      "zoonoses",
+      "surveillance",
+      "European",
+      "reports",
+      "ECDC"
+    ],
     "name": "ECDC Avian Influenza",
     "description": "Contains information related to avian influenza, including a distribution map of confirmed human cases, as well as guidelines for surveillance.",
     "url": "https://www.ecdc.europa.eu/en/avian-influenza-humans/surveillance-and-disease-data",
     "thumbnail": "/img/data_sources_thumbs/ecdc.png",
-    "data":["Clinical", "Phenotypic", "Epidemiology"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases"
-    ]
+    "data": [
+      "Clinical",
+      "Phenotypic",
+      "Epidemiology"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["biomedical research", "Federated European Genome-phenome Archive", "FEGA", "genomic data", "genetic", "phenotypes", "phenotypic", "DNA", "human data"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "biomedical research",
+      "Federated European Genome-phenome Archive",
+      "FEGA",
+      "genomic data",
+      "genetic",
+      "phenotypes",
+      "phenotypic",
+      "DNA",
+      "human data"
+    ],
     "name": "FEGA Sweden",
     "description": "Secure archiving and sharing of genetic and phenotypic data resulting from Swedish biomedical research projects. Access to the data only will be granted after a formal application procedure.",
     "url": "https://fega.nbis.se/",
     "thumbnail": "/img/data_sources_thumbs/fega-sweden-logo.png",
-    "data":["Genes and genomes", "Phenotypic"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Phenotypic"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["infectious", "disease", "influenza", "COVID-19", "SARS-CoV-2", "leishmaniases schistosomiasis", "Ebola", "Chagas disease", "Laboratory", "clinical", "epidemiology", "Infectious Disease Data Observatory", "patient data"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "infectious",
+      "disease",
+      "influenza",
+      "COVID-19",
+      "SARS-CoV-2",
+      "leishmaniases schistosomiasis",
+      "Ebola",
+      "Chagas disease",
+      "Laboratory",
+      "clinical",
+      "epidemiology",
+      "Infectious Disease Data Observatory",
+      "patient data"
+    ],
     "name": "Infectious Disease Data Observatory",
     "description": "Brings together multiple types of infectious disease data to improve the diagnosis and treatment of patients in the clinic. Access to the data held in the IDDO data repository has to be requested.",
     "url": "https://www.iddo.org/data-sharing/accessing-data",
     "thumbnail": "/img/data_sources_thumbs/IDDO.png",
-    "data":["Clinical", "Phenotypic", "Epidemiology"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases"
-    ]
+    "data": [
+      "Clinical",
+      "Phenotypic",
+      "Epidemiology"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["disease", "sample", "COVID-19", "SARS-CoV-2", "iPSC", "Animal genomes", "genomics", "proteomics", "cell biology", "clinical genetics", "BioSamples", "RNA", "RNA-seq", "transcriptomics", "assay", "array express", "ENA", "European Nucleotide Archive"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "disease",
+      "sample",
+      "COVID-19",
+      "SARS-CoV-2",
+      "iPSC",
+      "Animal genomes",
+      "genomics",
+      "proteomics",
+      "cell biology",
+      "clinical genetics",
+      "BioSamples",
+      "RNA",
+      "RNA-seq",
+      "transcriptomics",
+      "assay",
+      "array express",
+      "ENA",
+      "European Nucleotide Archive"
+    ],
     "name": "BioSamples",
     "description": "BioSamples stores and supplies metadata for a large number of biological samples used in research and development. The samples are either 'reference' samples or samples used in an assay database.",
     "url": "https://www.ebi.ac.uk/biosamples/",
     "thumbnail": "/img/data_sources_thumbs/BioSamples.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Cardiovascular Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["UK", "disease", "sample", "COVID-19", "SARS-CoV-2", "biological sample", "biobank", "biomedical", "infectious", "UK Biobank", "environmental data", "lifestyle data", "genotype data", "genes", "WGS", "whole genome sequencing", "WES", "exome", "genome", "biomarkers", "longitudinal data", "coding variation", "deep phenotyping", "phenotyping", "MRI"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "UK",
+      "disease",
+      "sample",
+      "COVID-19",
+      "SARS-CoV-2",
+      "biological sample",
+      "biobank",
+      "biomedical",
+      "infectious",
+      "UK Biobank",
+      "environmental data",
+      "lifestyle data",
+      "genotype data",
+      "genes",
+      "WGS",
+      "whole genome sequencing",
+      "WES",
+      "exome",
+      "genome",
+      "biomarkers",
+      "longitudinal data",
+      "coding variation",
+      "deep phenotyping",
+      "phenotyping",
+      "MRI"
+    ],
     "name": "UK Biobank",
     "description": "A large-scale biomedical database including biological and clinical data from 500K participants in the UK. Applications to access the data are welcomed from researchers anywhere in the world.",
     "url": "https://www.ukbiobank.ac.uk/",
     "thumbnail": "/img/data_sources_thumbs/UK_biobank_logo.png",
-    "data":["Phenotypic", "Biobank","Genes and genomes", "Clinical"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Cardiovascular Diseases", 
-      "Neurological Disorders", 
-      "Public Health",
-      "Psychiatric Disorders",
-      "Various Diseases"
-    ]
+    "data": [
+      "Phenotypic",
+      "Biobank",
+      "Genes and genomes",
+      "Clinical"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["ELSI","disease", "sample", "biobank", "infectious", "biobanking", "biological sample", "BBMRI-ERIC", "software"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "ELSI",
+      "disease",
+      "sample",
+      "biobank",
+      "infectious",
+      "biobanking",
+      "biological sample",
+      "BBMRI-ERIC",
+      "software"
+    ],
     "name": "BBMRI-ERIC",
     "description": "A biobanking infrastructure that promotes biomedical research. Samples can be accessed with appropriate permissions. Services, software, tools, and support with ELSI are also available.",
     "url": "https://www.bbmri-eric.eu/",
     "thumbnail": "/img/data_sources_thumbs/BBMRI-ERIC.png",
-    "data":["Biobank"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Cardiovascular Diseases", 
-      "Neurological Disorders"
-    ]
+    "data": [
+      "Biobank"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection"],
-    "search_tags": ["antibiotic resistance", "antimicrobial resistance", "AMR", "infectious", "disease", "survey", "animals", "livestock", "marine", "freshwater", "maps", "resistance bank"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection"
+    ],
+    "search_tags": [
+      "antibiotic resistance",
+      "antimicrobial resistance",
+      "AMR",
+      "infectious",
+      "disease",
+      "survey",
+      "animals",
+      "livestock",
+      "marine",
+      "freshwater",
+      "maps",
+      "resistance bank"
+    ],
     "name": "Resistance bank",
     "description": "The resistance bank is an open access repository for surveys and maps of antimicrobial resistance (AMR) in animals. It focuses particularly on low and middle-income countries.",
     "url": "https://resistancebank.org/",
-    "data":["Epidemiology","Genes and genomes"],
-    "thumbnail": "/img/data_sources_thumbs/resistance_bank.png",
-    "disease_type": []
+    "data": [
+      "Epidemiology",
+      "Genes and genomes"
+    ],
+    "thumbnail": "/img/data_sources_thumbs/resistance_bank.png"
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["disease", "genomics", "infectious", "gene expression", "sequence", "sequencing", "high throughput", "Array Express", "RNA-seq", "RNA", "Single cell RNA-seq", "miRNA", "transcripts", "genome-wide expression", "genotyping", "chip-seq", "non-coding", "methylation", "assay", "animal sequencing", "metabolomic profiling"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "disease",
+      "genomics",
+      "infectious",
+      "gene expression",
+      "sequence",
+      "sequencing",
+      "high throughput",
+      "Array Express",
+      "RNA-seq",
+      "RNA",
+      "Single cell RNA-seq",
+      "miRNA",
+      "transcripts",
+      "genome-wide expression",
+      "genotyping",
+      "chip-seq",
+      "non-coding",
+      "methylation",
+      "assay",
+      "animal sequencing",
+      "metabolomic profiling"
+    ],
     "name": "Array Express",
     "description": "ArrayExpress is an archive of functional genomics data, such as gene expression or DNA methylation profiling data. The data is open for reuse by the research community.",
     "url": "https://www.ebi.ac.uk/biostudies/arrayexpress/studies",
     "thumbnail": "/img/data_sources_thumbs/arrayexpress.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Genetic Disorders", 
-      "Drug Development", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["resource", "disease", "human variations", "variants", "clinical genetics", "annotation", "reference sequences", "somatic variants", "ClinVar", "ClinGen"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "resource",
+      "disease",
+      "human variations",
+      "variants",
+      "clinical genetics",
+      "annotation",
+      "reference sequences",
+      "somatic variants",
+      "ClinVar",
+      "ClinGen"
+    ],
     "name": "ClinVar",
     "description": "The primary site for the deposition and retrieval of variant data and annotations from individual submitters. It helps with explorations of how genomic variation is related to human health.",
     "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
-    "data":["Genes and genomes", "Clinical"],
-    "thumbnail": "/img/data_sources_thumbs/clinvar.png",
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Developmental Disorders"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Clinical"
+    ],
+    "thumbnail": "/img/data_sources_thumbs/clinvar.png"
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["drug discovery","ChEMBL", "bioactive", "bioactivity", "drug", "drug-like", "molecules", "genomics", "genomic data", "gene", "genetic", "chemical", "chemistry", "drug development", "ELIXIR Core Data Resource"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "drug discovery",
+      "ChEMBL",
+      "bioactive",
+      "bioactivity",
+      "drug",
+      "drug-like",
+      "molecules",
+      "genomics",
+      "genomic data",
+      "gene",
+      "genetic",
+      "chemical",
+      "chemistry",
+      "drug development",
+      "ELIXIR Core Data Resource"
+    ],
     "name": "ChEMBL",
     "description": "A manually curated database of bioactive molecules with drug-like properties. It brings together chemical, bioactivity, and genomic data to enable the translation of information into effective new drugs.",
     "url": "https://www.ebi.ac.uk/chembl/",
-    "data":["Molecular and cellular structures", "Genes and genomes", "Enzymes, pathways, interactions", "Chemical biology"],
+    "data": [
+      "Molecular and cellular structures",
+      "Genes and genomes",
+      "Enzymes, pathways, interactions",
+      "Chemical biology"
+    ],
     "thumbnail": "/img/data_sources_thumbs/chembl.jpeg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Gene Expression Omnibus", "GEO", "genomics", "gene expression", "array", "sequence", "microarray", "functional genomics", "RNA-seq", "RNA", "Single cell RNA-seq", "miRNA", "transcripts", "biochemistry"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Gene Expression Omnibus",
+      "GEO",
+      "genomics",
+      "gene expression",
+      "array",
+      "sequence",
+      "microarray",
+      "functional genomics",
+      "RNA-seq",
+      "RNA",
+      "Single cell RNA-seq",
+      "miRNA",
+      "transcripts",
+      "biochemistry"
+    ],
     "name": "Gene Expression Omnibus",
     "description": "An international public repository that archives and freely distributes microarray, next-generation sequencing, and other high-throughput functional genomics data submitted by the research community.",
     "url": "https://www.ncbi.nlm.nih.gov/geo/",
     "thumbnail": "/img/data_sources_thumbs/geo.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Genetic Disorders", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["genomics", "gene expression", "array", "sequence", "microarray", "functional genomics", "RNA-seq", "RNA", "Single cell RNA-seq", "transcripts", "scRNA-seq", "gemma"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "genomics",
+      "gene expression",
+      "array",
+      "sequence",
+      "microarray",
+      "functional genomics",
+      "RNA-seq",
+      "RNA",
+      "Single cell RNA-seq",
+      "transcripts",
+      "scRNA-seq",
+      "gemma"
+    ],
     "name": "Gemma",
     "description": "Gemma provides data, experimental design annotations, and differential expression analysis results for microarray and RNA-seq experiments. Gemma contains data from thousands of public studies.",
     "url": "https://gemma.msl.ubc.ca/home.html",
     "thumbnail": "/img/data_sources_thumbs/gemma.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Genetic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["genomics", "gene expression", "array", "sequence", "microarray", "functional genomics", "RNA-seq", "transcriptomics", "drug discovery", "disease", "treatment", "GENEVESTIGATOR"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "genomics",
+      "gene expression",
+      "array",
+      "sequence",
+      "microarray",
+      "functional genomics",
+      "RNA-seq",
+      "transcriptomics",
+      "drug discovery",
+      "disease",
+      "treatment",
+      "GENEVESTIGATOR"
+    ],
     "name": "GENEVESTIGATOR",
     "description": "Enables the simultaneous analysis of thousands of studies to find genes specifically related to a drug or disease. Free to use for those working in academia.",
     "url": "https://genevestigator.com/",
     "thumbnail": "/img/data_sources_thumbs/Genevestigator_logo.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Drug Development", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Protein Data Bank", "PDB", "structure", "biochemistry", "proteomic", "nucleic acids", "assemblies", "alpha fold", "model archive", "computational models", "3D structure", "biochemistry"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Protein Data Bank",
+      "PDB",
+      "structure",
+      "biochemistry",
+      "proteomic",
+      "nucleic acids",
+      "assemblies",
+      "alpha fold",
+      "model archive",
+      "computational models",
+      "3D structure",
+      "biochemistry"
+    ],
     "name": "Protein Data Bank",
     "description": "Includes over 170k 3D protein structures, nucleic acids, and complex assemblies available for download. Allows users to explore computational structural models alongside data from AlphaFold DB and ModelArchive.",
     "url": "https://www.rcsb.org/",
     "thumbnail": "/img/data_sources_thumbs/pdb.png",
-    "data":["Proteins and proteomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Cancer Genome Atlas", "TCGA", "genetic", "cancer", "patient", "NCI", "National Human Genome research institute", "epigenomic", "epigenetics", "transcriptomics", "proteomics", "proteins", "clinical data", "CNVs", "DNA", "methylation", "imaging", "miRNA", "microarray"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Cancer Genome Atlas",
+      "TCGA",
+      "genetic",
+      "cancer",
+      "patient",
+      "NCI",
+      "National Human Genome research institute",
+      "epigenomic",
+      "epigenetics",
+      "transcriptomics",
+      "proteomics",
+      "proteins",
+      "clinical data",
+      "CNVs",
+      "DNA",
+      "methylation",
+      "imaging",
+      "miRNA",
+      "microarray"
+    ],
     "name": "Cancer Genome Atlas",
     "description": "Has >2.5 petabytes of genomic, epigenomic, transcriptomic, and proteomic data from >10k patients across 33 cancer types. Raw data is under controlled access, but derived data is openly accessible.",
     "url": "https://www.cancer.gov/ccg/research/genome-sequencing/tcga",
     "thumbnail": "/img/data_sources_thumbs/tcga.png",
-    "data":["Proteins and proteomes", "Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["Cancer Imaging Archive", "TCIA", "National cancer institute", "clinical", "cancer imaging", "clinical imaging", "patient outcomes", "MRI", "CT", "digital histopathology", "genomics", "image analyses", "lung cancer", "melanoma", "cancer", "prostate cancer", "breast cancer", "ovarian cancer", "leukaemia"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Cancer Imaging Archive",
+      "TCIA",
+      "National cancer institute",
+      "clinical",
+      "cancer imaging",
+      "clinical imaging",
+      "patient outcomes",
+      "MRI",
+      "CT",
+      "digital histopathology",
+      "genomics",
+      "image analyses",
+      "lung cancer",
+      "melanoma",
+      "cancer",
+      "prostate cancer",
+      "breast cancer",
+      "ovarian cancer",
+      "leukaemia"
+    ],
     "name": "Cancer Imaging Archive",
     "description": "Collections of data that are typically patient cohorts related by a common disease, image modality, or type. Supporting data for the images are also available, e.g. patient outcomes & treatment details.",
     "url": "https://www.cancerimagingarchive.net/",
     "thumbnail": "/img/data_sources_thumbs/tcia.png",
-    "data":["Imaging", "Clinical","Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "data": [
+      "Imaging",
+      "Clinical",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics", "Cell and Molecular Biology"],
-    "data": ["Genes and genomes", "Proteins and proteomes"],
-    "search_tags": ["Cancer Cell Line Encyclopedia", "Cancer cell lines", "clinical", "cancer", "DNA", "mRNA expression", "copy number variants", "RNA expression", "epigenetic", "proteomics", "CCLE", "metabolomics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics",
+      "Cell and Molecular Biology"
+    ],
+    "data": [
+      "Genes and genomes",
+      "Proteins and proteomes"
+    ],
+    "search_tags": [
+      "Cancer Cell Line Encyclopedia",
+      "Cancer cell lines",
+      "clinical",
+      "cancer",
+      "DNA",
+      "mRNA expression",
+      "copy number variants",
+      "RNA expression",
+      "epigenetic",
+      "proteomics",
+      "CCLE",
+      "metabolomics"
+    ],
     "name": "Cancer Cell Line Encyclopedia",
     "description": "Genetic characterisation of a large panel of human cancer cell lines. It provides access to analyses and visualisations of DNA copy number, mRNA expression, mutation data, and more.",
     "url": "https://sites.broadinstitute.org/ccle",
     "thumbnail": "/img/data_sources_thumbs/ccle.jpg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["cBioPortal", "genomics", "cancer genomics", "cohort analysis", "clinical data", "tumour genomes"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "cBioPortal",
+      "genomics",
+      "cancer genomics",
+      "cohort analysis",
+      "clinical data",
+      "tumour genomes"
+    ],
     "name": "cBioPortal",
     "description": "An open-access resource enabling the interactive exploration of multidimensional cancer genomics datasets from more than 5,000 tumour samples.",
     "url": "https://www.cbioportal.org/",
-    "data":["Clinical","Genes and genomes"],
+    "data": [
+      "Clinical",
+      "Genes and genomes"
+    ],
     "thumbnail": "/img/data_sources_thumbs/cbioportal.png",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Alpha Fold Protein Structure Database", "Alpha Fold", "AlphaFold", "Protein Structure", "3D structure", "structure", "AI", "artificial intelligence", "DeepMind", "EMBL-EBi", "amino acids"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Alpha Fold Protein Structure Database",
+      "Alpha Fold",
+      "AlphaFold",
+      "Protein Structure",
+      "3D structure",
+      "structure",
+      "AI",
+      "artificial intelligence",
+      "DeepMind",
+      "EMBL-EBi",
+      "amino acids"
+    ],
     "name": "Alpha Fold Protein Structure Database",
     "description": "Contains over 200 million predictions of 3D protein structures based on amino acid sequence. The predictions were generated using AlphaFold, an AI system developed by DeepMind.",
     "url": "https://alphafold.ebi.ac.uk/",
     "thumbnail": "/img/data_sources_thumbs/alphafold_db.png",
-    "data":["Proteins and proteomes", "Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Drug Development", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["European Chemical Biology Database", "ECBD", "EU-OPENSCREEN", "novel molecular tool", "compounds", "early therapeutic candidate molecules", "compound", "assays"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "European Chemical Biology Database",
+      "ECBD",
+      "EU-OPENSCREEN",
+      "novel molecular tool",
+      "compounds",
+      "early therapeutic candidate molecules",
+      "compound",
+      "assays"
+    ],
     "name": "European Chemical Biology Database",
     "description": "The central hub for data generated within the EU-OPENSCREEN network. The network collaborates with external users to develop novel molecular tool compounds and early therapeautic candidate molecules.",
     "url": "https://ecbd.eu/",
     "thumbnail": "/img/data_sources_thumbs/ecdb.png",
-    "data":["Molecular and cellular structures"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Molecular and cellular structures"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Swedish COVID-19 Sample Collection database", "biobank", "Biobank Sverige", "COVID-19", "SARS-CoV-2", "tissue", "patient", "metadata"],
-    "name": "Swedish COVID-19 Sample Collection Database",
-    "description": "The Swedish COVID-19 Sample Collection Database contains information about COVID-19 samples in biobanks across Sweden and how to access them, along with metadata about the samples.",
-    "url": "https://biobanks.pathogens.se/",
-    "thumbnail": "/img/data_sources_thumbs/pathogens.png",
-    "data":["Biobank"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Infectious Diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["REACTOME", "bioinformatics tools", "pathways", "genome", "clinical", "modelling", "systems biology", "genetic", "genomics", "ELIXIR Core Data Resource"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "REACTOME",
+      "bioinformatics tools",
+      "pathways",
+      "genome",
+      "clinical",
+      "modelling",
+      "systems biology",
+      "genetic",
+      "genomics",
+      "ELIXIR Core Data Resource"
+    ],
     "name": "REACTOME",
     "description": "A graphical map of known biological processes and pathways. Provides tools to visualise, interpret, and analyse pathways to support research. Used for genome analysis, modelling, and systems biology.",
     "url": "https://reactome.org/",
-    "data":["Proteins and proteomes", "Genes and genomes", "Clinical", "Enzymes, pathways, interactions"],
+    "data": [
+      "Proteins and proteomes",
+      "Genes and genomes",
+      "Clinical",
+      "Enzymes, pathways, interactions"
+    ],
     "thumbnail": "/img/data_sources_thumbs/Reactome.png",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Proteomics identifications archive database", "PRIDE", "proteins", "peptide", "mass spectrometry", "MS", "mass-spectrometry", "ProteomeXchange", "ELIXIR Core Data Resource"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Proteomics identifications archive database",
+      "PRIDE",
+      "proteins",
+      "peptide",
+      "mass spectrometry",
+      "MS",
+      "mass-spectrometry",
+      "ProteomeXchange",
+      "ELIXIR Core Data Resource"
+    ],
     "name": "PRoteomics IDEntifications Archive database",
     "description": "A repository for mass spectrometry (MS) proteomics data. Includes protein and peptide identifications, with corresponding expression values, post-translational modifications, and supporting MS evidence.",
     "url": "https://www.ebi.ac.uk/pride/",
     "thumbnail": "/img/data_sources_thumbs/PRIDE.jpeg",
-    "data":["Proteins and proteomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["IntAct molecular interaction database", "analysis", "EMBL-EBI", "molecules", "interactions"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "IntAct molecular interaction database",
+      "analysis",
+      "EMBL-EBI",
+      "molecules",
+      "interactions"
+    ],
     "name": "IntAct Molecular Interaction Database",
     "description": "An open source database system and set of analysis tools for molecular interaction data. Interactions are derived from literature curation or direct user submission.",
     "url": "https://www.ebi.ac.uk/intact/",
     "thumbnail": "/img/data_sources_thumbs/intact.png",
-    "data":["Molecular and cellular structures", "Enzymes, pathways, interactions"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Molecular and cellular structures",
+      "Enzymes, pathways, interactions"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Mass Spectrometry Interactive Virtual Environment", "MassIVE", "Mass Spectrometry", "MS", "computational", "protein", "biochemistry", "ProteomeXchange"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Mass Spectrometry Interactive Virtual Environment",
+      "MassIVE",
+      "Mass Spectrometry",
+      "MS",
+      "computational",
+      "protein",
+      "biochemistry",
+      "ProteomeXchange"
+    ],
     "name": "MassIVE",
     "description": "A community resource developed by the NIH-funded Center for Computational Mass Spectrometry to promote the global, free exchange of mass spectrometry data.",
     "url": "https://massive.ucsd.edu/ProteoSAFe/static/massive.jsp",
     "thumbnail": "/img/data_sources_thumbs/MassIVE.png",
-    "data":["Proteins and proteomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Proteome Exchange", "ProteomeXchange", "protein", "proteomics", "MS", "mass spectrometry", "mass-spectrometry", "consortium"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Proteome Exchange",
+      "ProteomeXchange",
+      "protein",
+      "proteomics",
+      "MS",
+      "mass spectrometry",
+      "mass-spectrometry",
+      "consortium"
+    ],
     "name": "ProteomeXchange",
     "description": "A single point of submission for mass spectrometry proteomics data. It includes a globally coordinated data submission and dissemination pipeline that involves the main proteomics repositories.",
     "url": "https://www.proteomexchange.org/",
-    "data":["Proteins and proteomes"],
+    "data": [
+      "Proteins and proteomes"
+    ],
     "thumbnail": "/img/data_sources_thumbs/proteomexchange.jpeg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Metabolic Disorders", 
-      "Various Diseases"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["BioImage archive", "electron microscopy", "imaging", "bioimage archive", "cell", "tissue", "EMPIAR", "image data", "IDR", "BioStudies", "images", "bioimaging"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "BioImage archive",
+      "electron microscopy",
+      "imaging",
+      "bioimage archive",
+      "cell",
+      "tissue",
+      "EMPIAR",
+      "image data",
+      "IDR",
+      "BioStudies",
+      "images",
+      "bioimaging"
+    ],
     "name": "BioImage archive",
     "description": "A free, publicly available online resource that stores and distributes biological images. It accepts submissions of data from any imaging modality.",
     "url": "https://www.ebi.ac.uk/bioimage-archive/",
-    "data":["Imaging"],
-    "thumbnail": "/img/data_sources_thumbs/bioimagearchive.png",
-    "disease_type": [ 
-      "Cancer", 
-      "Neurological Disorders", 
-      "Infectious Diseases"
-    ]
+    "data": [
+      "Imaging"
+    ],
+    "thumbnail": "/img/data_sources_thumbs/bioimagearchive.png"
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Electron Microscopy Public Image Archive", "electron microscope", "imaging", "EMPIAR", "3D structure", "X-ray tomography", "cryogenic-EM maps", "cryo electron microscopy", "imaging data", "cryoelectron microscopy"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Electron Microscopy Public Image Archive",
+      "electron microscope",
+      "imaging",
+      "EMPIAR",
+      "3D structure",
+      "X-ray tomography",
+      "cryogenic-EM maps",
+      "cryo electron microscopy",
+      "imaging data",
+      "cryoelectron microscopy"
+    ],
     "name": "Electron Microscopy Public Image Archive",
     "description": "A public resource for raw electron microscopy images. Includes images underpinning 3D cryo-EM maps and tomograms, as well as 3D datasets generated using volume EM techniques and X-ray tomography.",
     "url": "https://www.ebi.ac.uk/empiar/",
     "thumbnail": "/img/data_sources_thumbs/EMPIAR.png",
-    "data":["Imaging"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Neurological Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Imaging"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["SciLifeLab Data Repository", "general", "Figshare", "data", "metadata", "repository", "general repository", "SciLifeLab", "scientific publications", "supplementary"],
-    "name": "SciLifeLab Data Repository",
-    "description": "SciLifeLab’s institutional instance of FigShare. It is an open, general purpose repository that includes many data types. Data can be submitted by those working in Swedish life science research.",
-    "url": "http://figshare.scilifelab.se/",
-    "data":["General"],
-    "thumbnail": "/img/data_sources_thumbs/figshare.jpg",
-    "disease_type": [ 
-      "General"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Dryad Digtal Repository", "general", "data", "repository", "general repository", "scientific publications", "supplementary"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Dryad Digtal Repository",
+      "general",
+      "data",
+      "Repository",
+      "general repository",
+      "scientific publications",
+      "supplementary"
+    ],
     "name": "Dryad Digital Repository",
     "description": "A general purpose repository for data underlying scientific and medical publications. Over 100,000 datasets have been made available.",
     "url": "https://datadryad.org/",
     "thumbnail": "/img/data_sources_thumbs/dryad.png",
-    "data":["General"],
-    "thumbnail_border": true,
-    "disease_type": [ 
+    "data": [
       "General"
-    ]
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Evolution and Biodiversity", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Mendeley Data", "general", "data", "repository", "general repository", "scientific publications", "supplementary"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Evolution and Biodiversity",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Mendeley Data",
+      "general",
+      "data",
+      "Repository",
+      "general repository",
+      "scientific publications",
+      "supplementary"
+    ],
     "name": "Mendeley Data",
     "description": "A general purpose, cloud-based repository intended for research data. Data can be shared privately or publicly, and are assigned unique identifiers.",
     "url": "https://data.mendeley.com/",
     "thumbnail": "/img/data_sources_thumbs/mendeley-data.jpeg",
-    "data":["General"],
-    "thumbnail_border": true,
-    "disease_type": [ 
+    "data": [
       "General"
-    ]
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection"],
-    "search_tags": ["infectious disease", "pathogen", "Folkhälsomyndigheten", "public health", "communicable disease", "COVID-19", "influenza", "Public Health Agency Sweden", "Folkhälasomyndigheten", "FoHM", "epidemiology", "registry data"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection"
+    ],
+    "search_tags": [
+      "infectious disease",
+      "pathogen",
+      "Folkhälsomyndigheten",
+      "public health",
+      "communicable disease",
+      "COVID-19",
+      "influenza",
+      "Public Health Agency Sweden",
+      "Folkhälasomyndigheten",
+      "FoHM",
+      "epidemiology",
+      "registry data"
+    ],
     "name": "Public Health Agency of Sweden",
     "description": "The Public Health Agency of Sweden (Folkhälsomyndigheten, FoHM) is responsible for issues related to public health. It collates and collects data on diseases that pose a threat to public health.",
     "url": "https://www.folkhalsomyndigheten.se/folkhalsorapportering-statistik/",
     "thumbnail": "/img/data_sources_thumbs/fohm.png",
-    "data":["Clinical", "Epidemiology"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Clinical",
+      "Epidemiology"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["infectious disease", "pathogen", "public health", "communicable disease", "COVID-19", "influenza", "Public Health Agency Sweden", "Folkhälsomyndigheten", "FoHM", "epidemiology", "registry data", "precision medicine", "general", "Swedish National Data Service", "SND", "DORIS", "social science"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "infectious disease",
+      "pathogen",
+      "public health",
+      "communicable disease",
+      "COVID-19",
+      "influenza",
+      "Public Health Agency Sweden",
+      "Folkhälsomyndigheten",
+      "FoHM",
+      "epidemiology",
+      "registry data",
+      "precision medicine",
+      "general",
+      "Swedish National Data Service",
+      "SND",
+      "DORIS",
+      "social science"
+    ],
     "name": "Swedish National Data Service",
     "description": "A service for Swedish research in humanities, social sciences, and medicine. It includes multiple collections of research data from Sweden, as well as links to international data.",
     "url": "https://snd.gu.se/en/catalogue",
     "thumbnail": "/img/data_sources_thumbs/SND.png",
-    "data":["Clinical", "Epidemiology", "Phenotypic"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Public Health", 
-      "Genetic Disorders", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Clinical",
+      "Epidemiology",
+      "Phenotypic"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Registry-based research", "registry", "population registers", "Swedish Research Council", "Sweden", "vetenskapsrådet", "VR", "healthcare", "health", "biobanks"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Registry-based research",
+      "registry",
+      "population registers",
+      "Swedish Research Council",
+      "Sweden",
+      "vetenskapsrådet",
+      "VR",
+      "healthcare",
+      "health",
+      "biobanks"
+    ],
     "name": "Registers in Sweden",
     "description": "A list of Swedish registry-based data sources, maintained by the Swedish Research Council. Users can link data from multiple registers, including healthcare records, biobanks, and research data.",
     "url": "https://www.registerforskning.se/en/registers-in-sweden/",
     "thumbnail": "/img/data_sources_thumbs/VR.png",
-    "data":["Clinical", "Epidemiology", "Biobank"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Public Health", 
-      "Cardiovascular Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Clinical",
+      "Epidemiology",
+      "Biobank"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["National Board of Health and Welfare", "health", "biobanks", "socialstyrelsen", "public health", "social care", "social welfare"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "National Board of Health and Welfare",
+      "health",
+      "biobanks",
+      "socialstyrelsen",
+      "public health",
+      "social care",
+      "social welfare"
+    ],
     "name": "National Board of Health and Welfare Statistical Databases",
     "description": "A set of databases related to health and welfare from the National Board of Health and Welfare. This Swedish governmental agency is responsible for ensuring high-quality health and social care.",
     "url": "https://www.socialstyrelsen.se/statistik-och-data/statistik/",
     "thumbnail": "/img/data_sources_thumbs/socialstyrelsen.png",
-    "data":["Clinical", "Epidemiology"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Public Health", 
-      "Cardiovascular Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Clinical",
+      "Epidemiology"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["health", "biobanks", "public health", "social care", "social welfare", "SCB", "statistics sweden"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "health",
+      "biobanks",
+      "public health",
+      "social care",
+      "social welfare",
+      "SCB",
+      "statistics sweden"
+    ],
     "name": "Statistics Sweden",
     "description": "Statistics Sweden has a large amount of data available for everyone to use free of charge under open licences. It includes geodata, public data, and data from different sectors.",
     "url": "https://www.scb.se/hitta-statistik/temaomraden/integration/regeringsuppdraget-registerdata-for-integration/",
     "thumbnail": "/img/data_sources_thumbs/SCB.png",
-    "data":["General"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Public Health", 
-      "Cardiovascular Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "General"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["genetics", "genome browser", "phenotype", "genetic data", "variants", "patient records", "DECIPHER"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "genetics",
+      "genome browser",
+      "phenotype",
+      "genetic data",
+      "variants",
+      "patient records",
+      "DECIPHER"
+    ],
     "name": "DECIPHER",
     "description": "An interactive database that includes a suite of tools related to the interpretation of genomic variants. It contains data from around 50k patients that have given consent for broad data sharing.",
     "url": "https://www.deciphergenomics.org/",
     "thumbnail": "/img/data_sources_thumbs/decipher.png",
-    "data":["Genes and genomes", "Clinical", "Phenotypic"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Developmental Disorders"
-    ]
+    "data": [
+      "Genes and genomes",
+      "Clinical",
+      "Phenotypic"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Skin Science Foundation Bioinformatics Hub", "bioinformatics", "dermatological diseases", "human diseases", "skin disease", "expression values", "transcriptomics"],
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Skin Science Foundation Bioinformatics Hub",
+      "bioinformatics",
+      "dermatological diseases",
+      "human diseases",
+      "skin disease",
+      "expression values",
+      "transcriptomics"
+    ],
     "name": "Skin Science Foundation Bioinformatics Hub",
     "description": "The hub includes a web platform through which users can gain open access to curated transcriptomic data from multiple inflammatory skin diseases.",
     "url": "https://biohub.skinsciencefoundation.org/labkey/home/project-begin.view?",
     "thumbnail": "/img/data_sources_thumbs/skin-sci-foundation.jpg",
-    "data":["Genes and genomes", "Clinical"],
-    "disease_type": [ 
-      "Immunological Diseases"
+    "data": [
+      "Genes and genomes",
+      "Clinical"
     ]
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Sequence Read Archive", "human", "short reads", "DNA sequencing data", "high-throughput", "clinical studies", "metagenomes", "human sequences", "SRA"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Sequence Read Archive",
+      "human",
+      "short reads",
+      "DNA sequencing data",
+      "high-throughput",
+      "clinical studies",
+      "metagenomes",
+      "human sequences",
+      "SRA"
+    ],
     "name": "Sequence Read Archive",
     "description": "A bioinformatics database that provides a public repository for DNA sequencing data. In particular, short reads generated using high‐throughput sequencing (typically less than 1000 base pairs long).",
     "url": "https://www.ncbi.nlm.nih.gov/sra/",
     "thumbnail": "/img/data_sources_thumbs/sra.png",
-    "data":["Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Genetic Disorders", 
-      "Cancer", 
-      "Infectious Diseases", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics", "Evolution and Biodiversity"],
-    "search_tags": ["proteins", "protein sequences", "biological function of proteins", "UniProt", "protein annotation", "peptides", "proteomes", "proteomics", "UniParc", "UniRef", "human diseases", "disease", "human data", "infectious", "ELIXIR Core Data Resource"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Epidemiology and Biology of Infection",
+      "Cell and Molecular Biology",
+      "Precision Medicine and Diagnostics",
+      "Evolution and Biodiversity"
+    ],
+    "search_tags": [
+      "proteins",
+      "protein sequences",
+      "biological function of proteins",
+      "UniProt",
+      "protein annotation",
+      "peptides",
+      "proteomes",
+      "proteomics",
+      "UniParc",
+      "UniRef",
+      "human diseases",
+      "disease",
+      "human data",
+      "infectious",
+      "ELIXIR Core Data Resource"
+    ],
     "name": "Uniprot",
     "description": "A comprehensive resource for protein sequence and annotation data. UniProt is a collaboration between EMBL-EBI, the Swiss Institute of Bioinformatics (SIB), and the Protein Information Resource (PIR).",
     "url": "https://www.uniprot.org/",
     "thumbnail": "/img/data_sources_thumbs/UniProt.png",
-    "data":["Proteins and proteomes", "Enzymes, pathways, interactions"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Drug Development", 
-      "Cancer", 
-      "Various Diseases"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Enzymes, pathways, interactions"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["Genomic Data Commons", "GDC", "Cancer", "precision medicine", "expression", "proteins", "DNA", "DNA sequence data", "methylation", "protein expression", "mRNA", "miRNA", "personalised medicine"],
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Genomic Data Commons",
+      "GDC",
+      "Cancer",
+      "precision medicine",
+      "expression",
+      "proteins",
+      "DNA",
+      "DNA sequence data",
+      "methylation",
+      "protein expression",
+      "mRNA",
+      "miRNA",
+      "personalised medicine"
+    ],
     "name": "Genomic Data Commons",
     "description": "A unified repository and cancer knowledge base that enables data sharing across cancer genomic studies in support of precision medicine.",
     "url": "https://gdc.cancer.gov/",
     "thumbnail": "/img/data_sources_thumbs/GDC.png",
-    "data":["Proteins and proteomes", "Genes and genomes", "Clinical"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "data": [
+      "Proteins and proteomes",
+      "Genes and genomes",
+      "Clinical"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Precision Medicine and Diagnostics"],
-    "search_tags": ["Proteomic Data Commons", "PDC", "Proteogenomic Cancer Atlas", "Proteomic data", "proteogenomic tumor datasets", "raw mass spectrometry-based data files", "NCI", "imaging", "genomic data", "medical image datasets", "personalised medicine", "precision medicine"
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Precision Medicine and Diagnostics"
+    ],
+    "search_tags": [
+      "Proteomic Data Commons",
+      "PDC",
+      "Proteogenomic Cancer Atlas",
+      "Proteomic data",
+      "proteogenomic tumor datasets",
+      "raw mass spectrometry-based data files",
+      "NCI",
+      "imaging",
+      "genomic data",
+      "medical image datasets",
+      "personalised medicine",
+      "precision medicine"
     ],
     "name": "Proteomic Data Commons",
     "description": "The PDC represents the NCI's largest public repository of comprehensive proteogenomic tumor datasets. It is essentially a Proteogenomic Cancer Atlas.",
     "url": "https://proteomic.datacommons.cancer.gov/pdc/",
     "thumbnail": "/img/data_sources_thumbs/PDC.png",
-    "data":["Proteins and proteomes"],
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer"
-    ]
+    "data": [
+      "Proteins and proteomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Evolution and Biodiversity"],
-    "search_tags": ["Biodiversity atlas", "biodiversity data", "natural history", "biodiversity research", "GBIF", "Living Atlases", "Swedish Biodiversity Data infrastructure", "SBDI"
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Evolution and Biodiversity"
+    ],
+    "search_tags": [
+      "Biodiversity atlas",
+      "biodiversity data",
+      "natural history",
+      "biodiversity research",
+      "GBIF",
+      "Living Atlases",
+      "Swedish Biodiversity Data infrastructure",
+      "SBDI"
     ],
     "name": "Swedish Biodiversity Data infrastructure",
     "description": "The Swedish access point for open biodiversity data. It includes many powerful tools and services that allow you to search, download, analyse, and visualise the data.",
     "url": "https://biodiversitydata.se/explore-analyze/data-and-tools/sbdi-datasets/",
     "thumbnail": "/img/data_sources_thumbs/sbdi.png",
-    "data":["Evolution and phylogeny", "Genes and genomes"],
-    "thumbnail_border": true,
-    "disease_type": []
+    "data": [
+      "Evolution and phylogeny",
+      "Genes and genomes"
+    ],
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Evolution and Biodiversity"],
-    "search_tags": ["Global Biodiversity Information Facility", "Biodiversity", "Evolution", "life on earth", "GBIF", "metadata", "sampling-event data", "occurrence data"
+    "type": [
+      "Data source"
+    ],
+    "ddls": [
+      "Evolution and Biodiversity"
+    ],
+    "search_tags": [
+      "Global Biodiversity Information Facility",
+      "Biodiversity",
+      "Evolution",
+      "life on earth",
+      "GBIF",
+      "metadata",
+      "sampling-event data",
+      "occurrence data"
     ],
     "name": "Global Biodiversity Information Facility",
     "description": "An international network and data infrastructure aimed at providing open access to data about all types of life on Earth. It supports the publication of four classes of datasets using widely accepted biodiversity data standards.",
     "url": "https://www.gbif.org/",
-    "data":["Evolution and phylogeny"],
+    "data": [
+      "Evolution and phylogeny"
+    ],
     "thumbnail": "/img/data_sources_thumbs/gbif.png",
-    "thumbnail_border": true,
-    "disease_type": []
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Evolution and Biodiversity"],
-    "search_tags": ["National Biodiversity Network Atlas", "Biodiversity atlas", "biodiversity data", "environmental data", "biodiversity", "NBN Atlas", "atlas"
+    "type": [
+      "Repository"
+    ],
+    "ddls": [
+      "Evolution and Biodiversity"
+    ],
+    "search_tags": [
+      "National Biodiversity Network Atlas",
+      "Biodiversity atlas",
+      "biodiversity data",
+      "environmental data",
+      "biodiversity",
+      "NBN Atlas",
+      "atlas"
     ],
     "name": "National Biodiversity Network Atlas",
     "description": "The NBN Atlas is the UK’s largest repository of publicly available biodiversity data. It also provides a platform to engage, educate and inform people about the natural world.",
     "url": "https://nbnatlas.org/",
     "thumbnail": "/img/data_sources_thumbs/nbn_atlas.jpg",
-    "data":["Evolution and phylogeny"],
-    "thumbnail_border": true,
-    "disease_type": []
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["AIDA Dataset Register", "NBIS",
-    "AIDA Data Hub",
-    "Compute resources",
-    "Helpdesk",
-    "Medical imaging",
-    "AI",
-    "Artificial intelligence",
-    "Clinical innovation",
-    "Data Sharing",
-    "Policy support",
-    "Application expertise",
-    "Pathology",
-    "Radiology",
-    "Datasets"
+    "data": [
+      "Evolution and phylogeny"
     ],
-    "name": "AIDA Dataset Register",
-    "data":["Imaging"],
-    "description": "Datasets shared on the AIDA Data Hub. Data is ideal for use as training data as it has considerable annotation.",
-    "url": "https://datahub.aida.scilifelab.se/datasets/",
-    "thumbnail": "/img/service_thumbnails/aida.jpg",
-    "disease_type": [ 
-      "Cancer", 
-      "Cardiovascular Diseases", 
-      "Immunological Diseases", 
-      "Various Diseases", 
-      "Infectious Diseases", 
-      "Public Health"
-    ]
+    "thumbnail_border": true
   },
   {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Human Protein Atlas", "NBIS",
-      "HPA",
-      "Human Protein Atlas",
-      "omics",
-      "protein",
-      "Human",
-      "genes",
-      "tissue",
-      "expression",
-      "localisation",
-      "localization"
+    "type": [
+      "Data source"
     ],
-    "name": "Human Protein Atlas",
-    "data":["Proteins and proteomes"],
-    "description": "The Human Protein Atlas aims to map all the human proteins in cells, tissues, and organs using an integration of various omics and imaging technologies",
-    "url": "https://www.proteinatlas.org/about/download",
-    "thumbnail": "/img/service_thumbnails/hpa.jpg",
-    "disease_type": [ 
-      "Cancer", 
-      "Immunological Diseases", 
-      "Various Diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["NBIS",
-      "Metabolic Atlas",
-      "GEM",
-      "genome",
-      "genes",
-      "models",
-      "reactions",
-      "metabolites",
-      "metatlas",
-      "genome-scale",
-      "enzyme",
-      "turnover",
-      "kcat"
+    "ddls": [
+      "Precision Medicine and Diagnostics",
+      "Epidemiology and Biology of Infection"
     ],
-    "name": "Metabolic Atlas",
-    "description": "Metabolic Atlas is a web platform integrating open-source genome scale metabolic models (GEMs) for easy browsing and analysis.",
-    "url": "https://metabolicatlas.org/",
-    "data":["Genes and genomes"],
-    "thumbnail": "/img/service_thumbnails/metatlas.jpg",
-    "disease_type": [ 
-      "Metabolic Disorders", 
-      "Cancer", 
-      "Various Diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["SubCellBarCode",
-      "Subcellular localisations",
-      "Proteins",
-      "Proteomics",
-      "Database",
-      "Tool",
-      "Portal"
-    ],
-    "name": "SubCellBarCode",
-    "description": "A collection of resources centred around the subcellular localisation of proteins.",
-    "url": "https://data.scilifelab.se/services/subcellbarcode/",
-    "data":["Molecular and cellular structures"],
-    "thumbnail": "/img/service_thumbnails/subcell.jpg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer", 
-      "Neurological Disorders", 
-      "Various Diseases"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Precision Medicine and Diagnostics"],
-    "search_tags": ["SweFreq",
-      "Genomics",
-      "Genetics",
-      "Database",
-      "Portal"
-    ],
-    "name": "SweFreq",
-    "data":["Genes and genomes"],
-    "description": "A website developed to make genomic datasets more findable and accessible",
-    "url": "https://swefreq.nbis.se/",
-    "thumbnail": "/img/service_thumbnails/scilifelab.jpg",
-    "disease_type": [ 
-      "Genetic Disorders"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["Human Developmental Cell Atlas", "NBIS",
-      "Human Developmental Cell Atlas",
-      "HDCA",
-      "HCA",
-      "Human Cell Atlas",
-      "embryo",
-      "Human",
-      "developmental biology",
-      "cell types"
-    ],
-    "name": "Human Developmental Cell Atlas",
-    "data":["Genes and genomes"],
-    "description": "A molecular atlas of human prenatal development, describing every cell type in detail and showing their spatial and temporal distributions in three dimensions.",
-    "url": "https://hdca-sweden.scilifelab.se/",
-    "thumbnail": "/img/service_thumbnails/hdca.jpg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Developmental Disorders"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Repository"],
-    "ddls": ["Epidemiology and Biology of Infection", "Cell and Molecular Biology", "Precision Medicine and Diagnostics"],
-    "search_tags": ["AI4Life BioImage Model Zoo", "BioImage Analysis", "AI Models", "Model Zoo", "Open Science", "Data-Driven Life Sciences", "DDLS", "modelling", "Artificial intelligence", "imaging"
-    ],
-    "name": "AI4Life BioImage Model Zoo",
-    "description": "A collaborative effort to bring artificial intelligence models to the bioimaging community.",
-    "url": "https://bioimage.io/#/",
-    "data":["Imaging"],
-    "thumbnail": "/img/service_thumbnails/bioimagezoo.jpg",
-    "thumbnail_border": true,
-    "disease_type": [ 
-      "Cancer Neurological Disorders", 
-      "Drug Development"
-    ]
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Epidemiology and Biology of Infection"],
-    "search_tags": ["COViMAPP",
-      "COVID-19",
-      "meta-analysis",
-      "metaanalysis",
-      "plasma",
-      "blood",
-      "serum",
-      "mass spectrometry",
-      "protein",
-      "proteome",
-      "proteomics",
-      "high-resolution isoelectric focusing",
-      "HiRIEF",
-      "liquid chromatography tandem mass spectrometry",
-      "LC-MS/MS",
-      "SARS-CoV-2",
-      "corona virus",
-      "coronavirus",
-      "infection",
-      "coronavirus disease",
-      "circulating",
-      "host response",
-      "organ damage",
-      "biomarkers",
-      "proximity extension assays",
-      "Olink",
-      "SomaScan"
-    ],
-    "name": "COViMAPP",
-    "data":["Proteins and proteomes", "Clinical"],
-    "description": "A meta-analysis resource showing changes in plasma proteins that occur during COVID-19.",
-    "url": "https://covimapp.serve.scilifelab.se",
-    "thumbnail": "/img/service_thumbnails/covimapp_logo.png",
-    "thumbnail_border": true,
-    "disease_type": []
-  },
-  {
-    "target": ["researchers"],
-    "type": ["Data source"],
-    "ddls": ["Precision Medicine and Diagnostics", "Epidemiology and Biology of Infection"],
     "search_tags": [
       "adiposetissue",
       "proteins",
@@ -1557,11 +2400,10 @@
     "description": "An open-access resource that integrates transcriptomic and proteomic data from diverse clinical cohorts, adipose cell types, and adipocyte studies to enable new discoveries in adipose biology.",
     "thumbnail": "/img/data_sources_thumbs/ATportal.png",
     "url": "https://adiposetissue.org",
-    "data":["Proteins and proteomes", "Genes and genomes", "Clinical"],
-    "disease_type": [ 
-      "Various diseases",
-      "Cardiovascular Diseases"
-      
+    "data": [
+      "Proteins and proteomes",
+      "Genes and genomes",
+      "Clinical"
     ]
   }
 ]

--- a/data/services.json
+++ b/data/services.json
@@ -7,6 +7,7 @@
       "Portal",
       "Tool"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "Precision Medicine Portal",
       "Precision Medicine",
@@ -108,6 +109,7 @@
     "type": [
       "database"
     ],
+    "data_source_type": ["Repository"],
     "search_tags": [
       "AI4Life BioImage Model Zoo", "BioImage Analysis", "AI Models", "Model Zoo", "Open Science", "Data-Driven Life Sciences", "DDLS", "modelling", "Artificial intelligence"
     ],
@@ -127,6 +129,7 @@
       "portal",
       "helpdesk"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "Pathogens portal",
       "infectious disease data",
@@ -209,6 +212,7 @@
       "database",
       "tool"
     ],
+    "data_source_type": ["Repository"],
     "search_tags": [
       "Data submission",
       "Data repository",
@@ -238,6 +242,7 @@
       "Portal",
       "Tool"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "NBIS",
       "Metabolic Atlas",
@@ -340,6 +345,7 @@
       "Portal",
       "Tool"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "NBIS",
       "HPA",
@@ -399,6 +405,7 @@
       "Database",
       "Helpdesk"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "NBIS",
       "AIDA Data Hub",
@@ -432,6 +439,7 @@
       "Database",
       "Tool"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "NBIS",
       "Human Developmental Cell Atlas",
@@ -488,6 +496,7 @@
       "tool",
       "portal"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "SubCellBarCode",
       "Subcellular localisations",
@@ -513,6 +522,7 @@
     "type": [
       "database"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "SweFreq",
       "Genomics",
@@ -1100,6 +1110,7 @@
     "type": [
       "database"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "COViMAPP",
       "COVID-19",
@@ -1146,6 +1157,7 @@
     "type": [
       "database"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "OrthoDisease",
       "ortholog",
@@ -1205,6 +1217,7 @@
     "type": [
       "database"
     ],
+    "data_source_type": ["Data source"],
     "search_tags": [
       "InParanoiDB",
       "ortholog groups",

--- a/layouts/resources/data_source.html
+++ b/layouts/resources/data_source.html
@@ -7,30 +7,29 @@
 {{ $r_stype := slice }}
 {{ $r_sddls := slice }}
 {{ $r_sdata := slice }}
-{{ $r_smain := slice }}
-{{ range sort .Site.Data.data_sources "name" }}
-      {{ $r_slist = $r_slist | append . }}
-      {{ $r_stype = $r_stype | append (apply .type "lower" ".") }}
-      {{ $r_sddls = $r_sddls | append (apply .ddls "lower" ".") }}
-      {{ $r_sdata = $r_sdata | append (apply .data "lower" ".") }}
-      {{ $r_smain = $r_smain | append (apply (split .maintained_by ", ") "lower" ".") }}
+
+{{/* Read data sources JSON file */}}
+{{ range .Site.Data.data_sources }}
+  {{ $r_slist = $r_slist | append . }}
+  {{ $r_stype = $r_stype | append (apply .type "lower" ".") }}
+  {{ $r_sddls = $r_sddls | append (apply .ddls "lower" ".") }}
+  {{ $r_sdata = $r_sdata | append (apply .data "lower" ".") }}
 {{ end }}
+
+{{/* Read services JSON file */}}
+{{ range where .Site.Data.services "data_source_type" "!=" nil }}
+  {{ $r_slist = $r_slist | append . }}
+  {{ $r_stype = $r_stype | append (apply .data_source_type "lower" ".") }}
+{{ end }}
+
+{{/* Sort and remove duplicates */}}
+{{ $r_slist = sort $r_slist "name" }}
 {{ $r_stype = $r_stype | uniq }}
 {{ $r_sddls = $r_sddls | uniq }}
 {{ $r_sdata = $r_sdata | uniq }}
-{{ $r_smain = $r_smain | uniq }}
-{{ $data_sources := dict "researchers" (dict "slist" $r_slist "stype" $r_stype "sddls" $r_sddls "sdata" $r_sdata "smain" $r_smain) }}
 
 <!-- Repository content -->
-<div class="data_sources-content">
-  {{ $targets := slice "researchers"}}
-  {{ range $target := $targets }}
-  {{ $target_slist := index (index $data_sources $target) "slist" }}
-  {{ $target_stype := index (index $data_sources $target) "stype" }}
-  {{ $target_sddls := index (index $data_sources $target) "sddls" }}
-  {{ $target_sdata := index (index $data_sources $target) "sdata" }}
-  {{ $target_smain := index (index $data_sources $target) "smain" }}
-  
+<div class="data_sources-content">  
   <div class="row">
     <div class="col-lg-2 mb-2 mb-lg-0 pe-lg-0">
       <div class="bg-light" style="position: sticky; top: 15px;">
@@ -47,7 +46,7 @@
             <div id="collapseFilters" class="accordion-collapse collapse d-lg-block" aria-labelledby="headingFilters">
               <div class="accordion-body">
                 <div class="input-group mb-3 mt-0">
-                  <input type="text" id="Search" class="form-control" placeholder="Name/Keywords" data-service-area="{{ $target }}_services">
+                  <input type="text" id="Search" class="form-control" placeholder="Name/Keywords">
                   <label class="form-control-label" for="Search" aria-labelledby="Search"></label>
                 </div>
                 <div class="accordion" id="innerAccordion">
@@ -59,7 +58,7 @@
                     </h2>
                     <div id="collapseResourceType" class="accordion-collapse collapse show" aria-labelledby="headingResourceType">
                       <div class="accordion-body">
-                        {{ range sort $target_stype }}
+                        {{ range sort $r_stype }}
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" id="{{ . }}" name="type" value="{{ . | urlize }}">
                           <label class="form-check-label" for="{{ . }}">{{ . | humanize }}</label>
@@ -77,7 +76,7 @@
                     </h2>
                     <div id="collapseDataType" class="accordion-collapse collapse" aria-labelledby="headingDataType">
                       <div class="accordion-body">
-                        {{ range sort $target_sdata }}
+                        {{ range sort $r_sdata }}
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" id="{{ . }}" name="data" value="{{ . | urlize }}">
                           <label class="form-check-label" for="{{ . }}">{{ . | humanize }}</label>
@@ -95,7 +94,7 @@
                     </h2>
                     <div id="collapseScientificArea" class="accordion-collapse collapse" aria-labelledby="headingScientificArea">
                       <div class="accordion-body">
-                        {{ range sort $target_sddls }}
+                        {{ range sort $r_sddls }}
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" id="{{ . }}" name="ddls" value="{{ . | urlize }}">
                           <label class="form-check-label" for="{{ . }}">{{ . | humanize }}</label>
@@ -112,9 +111,10 @@
       </div>
     </div>
     <div class="col-lg">
-      <div id="{{ $target }}_services" class="row g-3 mb-5">
-        {{ range $target_slist }}
-        <div class="col-md-6 col-lg-4 service" data-stype="{{ delimit (apply .type "urlize" ".") " " }}" 
+      <div id="services" class="row g-3 mb-5">
+        {{ range $r_slist }}
+        {{ $type := cond (isset . "data_source_type") .data_source_type .type }}
+        <div class="col-md-6 col-lg-4 service" data-stype="{{ delimit (apply $type "urlize" ".") " " }}" 
             data-sddls="{{ delimit (apply .ddls "urlize" ".") ":" }}"
             {{ with .search_tags }}data-search-tags="{{ delimit . ":" | lower }}"{{ end }}
             data-sdata="{{ delimit (apply .data "urlize" ".") ":" }}"
@@ -131,8 +131,8 @@
             <div class="p-2">
               {{ .description }}
             </div>
-            <div class="px-2">
-              <b>Type:</b> {{ delimit (apply .type "strings.FirstUpper" ".") ", " }}
+            <div class="px-2 pb-2">
+              <b>Type:</b> {{ delimit (apply $type "strings.FirstUpper" ".") ", " }}
             </div>
           </div>
         </div>
@@ -143,8 +143,6 @@
       </div>
     </div>
   </div>
-
-  {{ end }}
 </div>
 
 <script>


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR integrates services into data sources i.e. if a service is also a data source, instead of creating another entry in the `data_sources.json`, simply adding `data_source_type: ["..."]` (with right type) will populate it.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added `data_source_type` field in the `services.json` to the items that should be listed in the data sources page too.
- Removed redundant items from `data_sources.json` along with unused fields in the file
- Tidied up the code in `data_sources.html`
- Added `back to top` button for services and data sources page for easy navigation

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->

The `data_source.json` shows large changes because of the reformatting and removal of extra items/fields.
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1455](https://scilifelab.atlassian.net/browse/FREYA-1455)
