### PR TITLE
FREYA-1459: Add schema for open science data

### DIFF
--- a/schemas/data/open_science/collaborative_initiatives.schema.json
+++ b/schemas/data/open_science/collaborative_initiatives.schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/open_science/collaborative_initiatives.schema.json",
+    "title": "Open Science collaborative initiatives schema",
+    "description": "Schema for validating collaborative initiatives objects used in the open science section of data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "title",
+        "description",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the initiative."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description about the initiative."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL linking to the initiative.",
+          "pattern": "^(https?:\\/\\/|\\/).+"
+        }
+      },
+      "additionalProperties": false
+    }
+}

--- a/schemas/data/open_science/events.schema.json
+++ b/schemas/data/open_science/events.schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/open_science/events.schema.json",
+    "title": "Open Science events schema",
+    "description": "Schema for validating events objects used in the open science section of data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "title",
+        "type",
+        "date_start",
+        "venue",
+        "event_url",
+        "description"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the event."
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Type of the event (examples: Event, Conference, etc)."
+        },
+        "date_start": {
+          "type": "string",
+          "description": "Start date of the event in YYYY-MM-DD format.",
+          "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+        },
+        "time_start": {
+          "type": "string",
+          "description": "OPTIONAL: Start time of the event in HH:MM format.",
+          "pattern": "^([0-9]{2}:[0-9]{2})?$"
+        },
+        "date_end": {
+          "type": "string",
+          "description": "OPTIONAL: End date of the event in YYYY-MM-DD format.",
+          "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+        },
+        "time_end": {
+          "type": "string",
+          "description": "OPTIONAL: End time of the event in HH:MM format.",
+          "pattern": "^([0-9]{2}:[0-9]{2})?$"
+        },
+        "venue": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Event venue."
+        },
+        "organisers": {
+          "type": "string",
+          "description": "OPTIONAL: Name of institute or team who organise the event."
+        },
+        "event_url": {
+          "type": "string",
+          "description": "URL linking to the event.",
+          "pattern": "^(https?:\\/\\/|\\/).+"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description about the event."
+        }
+      },
+      "additionalProperties": false
+    }
+}

--- a/schemas/data/open_science/events.schema.json
+++ b/schemas/data/open_science/events.schema.json
@@ -28,7 +28,7 @@
         "date_start": {
           "type": "string",
           "description": "Start date of the event in YYYY-MM-DD format.",
-          "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
         },
         "time_start": {
           "type": "string",

--- a/schemas/data/open_science/glossary.schema.json
+++ b/schemas/data/open_science/glossary.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/open_science/glossary.schema.json",
+    "title": "Open Science glossary schema",
+    "description": "Schema for validating glossary objects used in the open science section of data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "term",
+        "definition",
+        "source",
+        "source_name"
+      ],
+      "properties": {
+        "term": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title/name of the glossary."
+        },
+        "definition": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description about the glossary."
+        },
+        "source": {
+          "type": "string",
+          "description": "URL linking to the glossary.",
+          "pattern": "^(https?:\\/\\/|\\/).+"
+        },
+        "source_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short title to be used for hyperlink text of the glossary."
+        },
+        "image": {
+          "type": "string",
+          "description": "Path to a image for the glossary.",
+          "pattern": "^\\/img\\/open_science\\/glossary\\/[^\\s]+\\.(jpg|jpeg|png|svg)$"
+        },
+        "image_alt": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Alt text for the provided image of the glossary."
+        }
+      },
+      "additionalProperties": false
+    }
+}

--- a/schemas/data/open_science/initiatives.schema.json
+++ b/schemas/data/open_science/initiatives.schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/open_science/initiatives.schema.json",
+    "title": "Open Science initiatives schema",
+    "description": "Schema for validating initiatives objects used in the open science section of data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "title",
+        "description",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the initiative."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description about the initiative."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL linking to the initiative.",
+          "pattern": "^(https?:\\/\\/|\\/).+"
+        }
+      },
+      "additionalProperties": false
+    }
+}

--- a/schemas/data/open_science/team.schema.json
+++ b/schemas/data/open_science/team.schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/open_science/team.schema.json",
+    "title": "Open Science team schema",
+    "description": "Schema for validating team member json used in the open science section of data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "name",
+        "title",
+        "image"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the team member."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title of the team member."
+        },
+        "image": {
+          "type": "string",
+          "description": "Path to a image of the team member.",
+          "pattern": "^\\/img\\/open_science\\/team_photos\\/[^\\s]+\\.(jpg|jpeg|png|svg)$"
+        }
+      },
+      "additionalProperties": false
+    }
+}


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR adds schema to validate `data/open_science` json files
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Add 5 new schema files in `schema/data/open_Science`
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1459](https://scilifelab.atlassian.net/browse/FREYA-1459)
