### PR TITLE
Put back disease_type in data sources

### DIFF
--- a/data/data_sources.json
+++ b/data/data_sources.json
@@ -28,7 +28,10 @@
       "Genes and genomes",
       "Biobank"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cardiovascular Diseases"
+    ]
   },
   {
     "type": [
@@ -75,7 +78,11 @@
     "data": [
       "General"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Public Health",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -115,7 +122,11 @@
       "Genes and genomes",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -152,7 +163,12 @@
       "Proteins and proteomes",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -187,7 +203,12 @@
       "Molecular and cellular structures",
       "Enzymes, pathways, interactions"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -220,7 +241,12 @@
       "Genes and genomes",
       "Evolution and phylogeny"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Infectious Diseases",
+      "Public Health",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -249,7 +275,8 @@
       "Chemical biology",
       "Enzymes, pathways, interactions"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -281,7 +308,8 @@
       "Proteins and proteomes",
       "Evolution and phylogeny"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -310,7 +338,10 @@
       "Phenotypic",
       "Biobank"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Rare Diseases"
+    ]
   },
   {
     "type": [
@@ -340,7 +371,8 @@
       "Molecular and cellular structures",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -369,7 +401,8 @@
       "Molecular and cellular structures",
       "Proteins and proteomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -401,7 +434,12 @@
       "Proteins and proteomes",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -429,7 +467,12 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -463,7 +506,8 @@
       "Evolution and phylogeny",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -496,7 +540,13 @@
       "Evolution and phylogeny",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Developmental Disorders",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -520,7 +570,8 @@
     "data": [
       "Chemical biology",
       "Molecular and cellular structures"
-    ]
+    ],
+    "disease_type": []
   },
   {
     "type": [
@@ -544,7 +595,13 @@
     "data": [
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Neurological Disorders",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -573,7 +630,8 @@
       "Molecular and cellular structures",
       "Proteins and proteomes",
       "Evolution and phylogeny"
-    ]
+    ],
+    "disease_type": []
   },
   {
     "type": [
@@ -601,7 +659,8 @@
       "Enzymes, pathways, interactions",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -634,7 +693,8 @@
       "Molecular and cellular structures",
       "Phenotypic"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -672,7 +732,12 @@
       "Molecular and cellular structures",
       "Chemical biology"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -702,7 +767,8 @@
       "Proteins and proteomes",
       "Molecular and cellular structures",
       "Chemical biology"
-    ]
+    ],
+    "disease_type": []
   },
   {
     "type": [
@@ -727,7 +793,8 @@
       "Chemical biology",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -758,7 +825,8 @@
       "Chemical biology",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -787,7 +855,13 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -815,7 +889,8 @@
     "data": [
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -847,7 +922,14 @@
       "Phenotypic",
       "Clinical"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Developmental Disorders",
+      "Psychiatric Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -876,7 +958,12 @@
     "data": [
       "General"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Cardiovascular Diseases",
+      "Metabolic Disorders"
+    ]
   },
   {
     "type": [
@@ -905,7 +992,8 @@
     "data": [
       "Enzymes, pathways, interactions"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -938,7 +1026,8 @@
       "Clinical",
       "Phenotypic"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -987,7 +1076,13 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1018,7 +1113,10 @@
       "Epidemiology"
     ],
     "thumbnail": "/img/data_sources_thumbs/ecdc.png",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Infectious Diseases"
+    ]
   },
   {
     "type": [
@@ -1049,7 +1147,10 @@
       "Phenotypic",
       "Epidemiology"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Infectious Diseases"
+    ]
   },
   {
     "type": [
@@ -1079,7 +1180,12 @@
       "Genes and genomes",
       "Phenotypic"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1113,7 +1219,10 @@
       "Phenotypic",
       "Epidemiology"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Infectious Diseases"
+    ]
   },
   {
     "type": [
@@ -1152,7 +1261,12 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Infectious Diseases",
+      "Cardiovascular Diseases"
+    ]
   },
   {
     "type": [
@@ -1200,7 +1314,15 @@
       "Genes and genomes",
       "Clinical"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Cardiovascular Diseases",
+      "Neurological Disorders",
+      "Public Health",
+      "Psychiatric Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1229,7 +1351,12 @@
     "data": [
       "Biobank"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Cardiovascular Diseases",
+      "Neurological Disorders"
+    ]
   },
   {
     "type": [
@@ -1259,7 +1386,8 @@
       "Epidemiology",
       "Genes and genomes"
     ],
-    "thumbnail": "/img/data_sources_thumbs/resistance_bank.png"
+    "thumbnail": "/img/data_sources_thumbs/resistance_bank.png",
+    "disease_type": []
   },
   {
     "type": [
@@ -1301,7 +1429,13 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Genetic Disorders",
+      "Drug Development",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1331,7 +1465,12 @@
       "Genes and genomes",
       "Clinical"
     ],
-    "thumbnail": "/img/data_sources_thumbs/clinvar.png"
+    "thumbnail": "/img/data_sources_thumbs/clinvar.png",
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Developmental Disorders"
+    ]
   },
   {
     "type": [
@@ -1369,7 +1508,11 @@
       "Chemical biology"
     ],
     "thumbnail": "/img/data_sources_thumbs/chembl.jpeg",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -1404,7 +1547,13 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Genetic Disorders",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1434,7 +1583,12 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Genetic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1464,7 +1618,12 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Drug Development",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1496,7 +1655,12 @@
     "data": [
       "Proteins and proteomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1536,7 +1700,10 @@
       "Proteins and proteomes",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -1575,7 +1742,10 @@
       "Clinical",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -1607,7 +1777,10 @@
     "description": "Genetic characterisation of a large panel of human cancer cell lines. It provides access to analyses and visualisations of DNA copy number, mRNA expression, mutation data, and more.",
     "url": "https://sites.broadinstitute.org/ccle",
     "thumbnail": "/img/data_sources_thumbs/ccle.jpg",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -1632,7 +1805,10 @@
       "Genes and genomes"
     ],
     "thumbnail": "/img/data_sources_thumbs/cbioportal.png",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -1665,7 +1841,12 @@
       "Proteins and proteomes",
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Drug Development",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1693,7 +1874,12 @@
     "data": [
       "Molecular and cellular structures"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1727,7 +1913,12 @@
       "Enzymes, pathways, interactions"
     ],
     "thumbnail": "/img/data_sources_thumbs/Reactome.png",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1757,7 +1948,12 @@
     "data": [
       "Proteins and proteomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1784,7 +1980,12 @@
       "Molecular and cellular structures",
       "Enzymes, pathways, interactions"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1813,7 +2014,12 @@
     "data": [
       "Proteins and proteomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1842,7 +2048,12 @@
       "Proteins and proteomes"
     ],
     "thumbnail": "/img/data_sources_thumbs/proteomexchange.jpeg",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Metabolic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1874,7 +2085,12 @@
     "data": [
       "Imaging"
     ],
-    "thumbnail": "/img/data_sources_thumbs/bioimagearchive.png"
+    "thumbnail": "/img/data_sources_thumbs/bioimagearchive.png",
+    "disease_type": [
+      "Cancer",
+      "Neurological Disorders",
+      "Infectious Diseases"
+    ]
   },
   {
     "type": [
@@ -1905,7 +2121,13 @@
     "data": [
       "Imaging"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer",
+      "Infectious Diseases",
+      "Neurological Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -1933,7 +2155,10 @@
     "data": [
       "General"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "General"
+    ]
   },
   {
     "type": [
@@ -1961,7 +2186,10 @@
     "data": [
       "General"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "General"
+    ]
   },
   {
     "type": [
@@ -1992,7 +2220,8 @@
       "Clinical",
       "Epidemiology"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -2030,7 +2259,12 @@
       "Epidemiology",
       "Phenotypic"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Public Health",
+      "Genetic Disorders",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2061,7 +2295,12 @@
       "Epidemiology",
       "Biobank"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Public Health",
+      "Cardiovascular Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2088,7 +2327,12 @@
       "Clinical",
       "Epidemiology"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Public Health",
+      "Cardiovascular Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2114,7 +2358,12 @@
     "data": [
       "General"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Public Health",
+      "Cardiovascular Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2143,7 +2392,11 @@
       "Clinical",
       "Phenotypic"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Developmental Disorders"
+    ]
   },
   {
     "type": [
@@ -2169,6 +2422,9 @@
     "data": [
       "Genes and genomes",
       "Clinical"
+    ],
+    "disease_type": [
+      "Immunological Diseases"
     ]
   },
   {
@@ -2198,7 +2454,13 @@
     "data": [
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Genetic Disorders",
+      "Cancer",
+      "Infectious Diseases",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2235,7 +2497,12 @@
       "Proteins and proteomes",
       "Enzymes, pathways, interactions"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Drug Development",
+      "Cancer",
+      "Various Diseases"
+    ]
   },
   {
     "type": [
@@ -2268,7 +2535,10 @@
       "Genes and genomes",
       "Clinical"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -2298,7 +2568,10 @@
     "data": [
       "Proteins and proteomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": [
+      "Cancer"
+    ]
   },
   {
     "type": [
@@ -2325,7 +2598,8 @@
       "Evolution and phylogeny",
       "Genes and genomes"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -2351,7 +2625,8 @@
       "Evolution and phylogeny"
     ],
     "thumbnail": "/img/data_sources_thumbs/gbif.png",
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -2376,7 +2651,8 @@
     "data": [
       "Evolution and phylogeny"
     ],
-    "thumbnail_border": true
+    "thumbnail_border": true,
+    "disease_type": []
   },
   {
     "type": [
@@ -2402,6 +2678,10 @@
       "Proteins and proteomes",
       "Genes and genomes",
       "Clinical"
+    ],
+    "disease_type": [
+      "Various diseases",
+      "Cardiovascular Diseases"
     ]
   }
 ]

--- a/schemas/data/data_sources.schema.json
+++ b/schemas/data/data_sources.schema.json
@@ -81,6 +81,14 @@
           "minItems": 1,
           "uniqueItems": true,
           "description": "Types of data that exists in the data source."
+        },
+        "disease_type": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "OPTIONAL: Disease type relevant to the data source. Used by precision medicine portal."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
The precision medicine portal used the `disease_type` in the `data_sources.json` file, so putting it back
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- put back `disease_type` in the `data_sources.json` file

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->

This is to undo something done in previous PR, so no existing jira issue
 
### ✅ Checklist
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review
