### PR TITLE
FREYA-1458: Add service schema

### DIFF
--- a/data/services.json
+++ b/data/services.json
@@ -1083,7 +1083,6 @@
       "python",
       "bioinformatics",
       "multiqc",
-      "bioinformatics",
       "pypi",
       "biconda",
       "aggregate",

--- a/schemas/data/resources.schema.json
+++ b/schemas/data/resources.schema.json
@@ -51,14 +51,7 @@
         "url": {
           "type": "string",
           "description": "URL linking to the resource.",
-          "oneOf": [
-            {
-              "format": "uri"
-            },
-            {
-              "pattern": "^\\/[^\\s]+$"
-            }
-          ]
+          "pattern": "^(https?:\\/\\/|\\/).+"
         },
         "thumbnail": {
           "type": "string",

--- a/schemas/data/resources.schema.json
+++ b/schemas/data/resources.schema.json
@@ -22,15 +22,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "Interactive guide",
-              "Data sources",
-              "Compute resources",
-              "Storage resources",
-              "Alternative metrics",
-              "portal",
-              "helpdesk"
-            ]
+            "minLength": 1
           },
           "minItems": 1,
           "uniqueItems": true,
@@ -59,7 +51,14 @@
         "url": {
           "type": "string",
           "description": "URL linking to the resource.",
-          "pattern": "^(https?:\\/\\/|\\/).+"
+          "oneOf": [
+            {
+              "format": "uri"
+            },
+            {
+              "pattern": "^\\/[^\\s]+$"
+            }
+          ]
         },
         "thumbnail": {
           "type": "string",
@@ -68,7 +67,7 @@
         },
         "thumbnail_border": {
           "type": "boolean",
-          "description": "Whether to display a border around the thumbnail image.",
+          "description": "OPTIONAL: Whether to display a border around the thumbnail image.",
           "default": false
         },
         "created_by": {

--- a/schemas/data/resources.schema.json
+++ b/schemas/data/resources.schema.json
@@ -33,14 +33,17 @@
             ]
           },
           "minItems": 1,
+          "uniqueItems": true,
           "description": "One or more categories describing the type of resource."
         },
         "search_tags": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "minItems": 1,
+          "uniqueItems": true,
           "description": "Search keywords associated with the resource."
         },
         "name": {

--- a/schemas/data/services.schema.json
+++ b/schemas/data/services.schema.json
@@ -1,0 +1,139 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "/schemas/data/services.schema.json",
+    "title": "Services Schema",
+    "description": "Schema for validating service objects used in the data.scilifelab.se",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "required": [
+        "target",
+        "type",
+        "search_tags",
+        "name",
+        "description",
+        "url",
+        "maintained_by"
+      ],
+      "properties": {
+        "target": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "researchers",
+              "facilities"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Target audience for the service."
+        },
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Portal",
+              "Tool",
+              "Helpdesk",
+              "Database",
+              "portal",
+              "helpdesk",
+              "tool",
+              "database",
+              "Storage resources",
+              "Compute resources",
+              "Workflow"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "One or more categories describing the type of service."
+        },
+        "data_source_type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Data source",
+              "Repository"
+            ]
+          },
+          "uniqueItems": true,
+          "description": "OPTIONAL: Type of data source associated with the service."
+        },
+        "search_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Search keywords associated with the service."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Title or name of the service."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short description about the service."
+        },
+        "thumbnail": {
+          "type": "string",
+          "description": "OPTIONAL: Path to a thumbnail image for the service.",
+          "pattern": "^\\/img\\/service_thumbnails\\/[^\\s]+\\.(jpg|jpeg|png|svg)$"
+        },
+        "thumbnail_border": {
+          "type": "boolean",
+          "description": "Optional, whether to display a border around the thumbnail image.",
+          "default": false
+        },
+        "url": {
+          "type": "string",
+          "description": "URL linking to the service.",
+          "pattern": "^(https?:\\/\\/|\\/).+"
+        },
+        "maintained_by": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the individual or organization that maintains the service."
+        },
+        "maintained_by_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL: Web address of the maintaining organization or individual."
+        },
+        "support_email": {
+          "type": "string",
+          "format": "email",
+          "description": "OPTIONAL: Email address to contact for support regarding the service."
+        },
+        "support_website": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL: Website URL for service support or documentation."
+        },
+        "support_github": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL: GitHub repository URL for the service."
+        },
+        "support_status": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL: Status page URL for the service."
+        },
+        "support_slack": {
+          "type": "string",
+          "format": "uri",
+          "description": "OPTIONAL: Slack channel or workspace URL for service support."
+        }
+      },
+      "additionalProperties": false
+    }
+}

--- a/schemas/data/services.schema.json
+++ b/schemas/data/services.schema.json
@@ -20,7 +20,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "enum": [
+              "researchers",
+              "facilities"
+            ]
           },
           "minItems": 1,
           "uniqueItems": true,
@@ -40,10 +43,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "Data source",
-              "Repository"
-            ]
+            "minLength": 1
           },
           "uniqueItems": true,
           "description": "OPTIONAL: Type of data source associated with the service."

--- a/schemas/data/services.schema.json
+++ b/schemas/data/services.schema.json
@@ -20,10 +20,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "researchers",
-              "facilities"
-            ]
+            "minLength": 1
           },
           "minItems": 1,
           "uniqueItems": true,
@@ -33,19 +30,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "Portal",
-              "Tool",
-              "Helpdesk",
-              "Database",
-              "portal",
-              "helpdesk",
-              "tool",
-              "database",
-              "Storage resources",
-              "Compute resources",
-              "Workflow"
-            ]
+            "minLength": 1
           },
           "minItems": 1,
           "uniqueItems": true,
@@ -90,13 +75,20 @@
         },
         "thumbnail_border": {
           "type": "boolean",
-          "description": "Optional, whether to display a border around the thumbnail image.",
+          "description": "OPTIONAL: Whether to display a border around the thumbnail image.",
           "default": false
         },
         "url": {
           "type": "string",
           "description": "URL linking to the service.",
-          "pattern": "^(https?:\\/\\/|\\/).+"
+          "oneOf": [
+            {
+              "format": "uri"
+            },
+            {
+              "pattern": "^\\/[^\\s]+$"
+            }
+          ]
         },
         "maintained_by": {
           "type": "string",

--- a/schemas/data/services.schema.json
+++ b/schemas/data/services.schema.json
@@ -81,14 +81,7 @@
         "url": {
           "type": "string",
           "description": "URL linking to the service.",
-          "oneOf": [
-            {
-              "format": "uri"
-            },
-            {
-              "pattern": "^\\/[^\\s]+$"
-            }
-          ]
+          "pattern": "^(https?:\\/\\/|\\/).+"
         },
         "maintained_by": {
           "type": "string",


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This pull request introduces schema enhancements and data cleanup for better validation and organisation of service-related data. Key changes include the addition of a new JSON schema for `services`, updates to existing schemas for stricter validation, and the removal of duplicate entries in the `data/services.json` file.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- **Schema Enhancements:**
-- New `services.schema.json` Introduced a comprehensive schema for validating service objects
-- Updates to `resources.schema.json`**: Added `uniqueItems: true` to enforce uniqueness in arrays and a `minLength: 1` constraint for string items in `search_tags` to ensure non-empty values.
- **Data Cleanup:**
-- Deduplication in `services.json`: Removed a duplicate `"bioinformatics"` entry from the `data/services.json` file to improve data consistency.

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1458](https://scilifelab.atlassian.net/browse/FREYA-1458)
