### PR TITLE
FREYA-1428 : Pull data centre event directly from scilifelab.se

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -495,8 +495,7 @@ h5 a:hover {
   }
 }
 .data_sources-content .accordion-button.custom-padding {
-  padding-left: 0.5rem; /* Adjust as needed */
-  padding-right: 0.5rem; /* Adjust as needed */
+  padding: 0.5rem;
 }
 #job-filters .accordion {
   --bs-accordion-bg: inherit; /* Use the parent bg-light color */
@@ -516,8 +515,7 @@ h5 a:hover {
   }
 }
 #job-filters .accordion-button.custom-padding {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding: 0.5rem;
   text-align: left;
 }
 
@@ -546,8 +544,7 @@ h5 a:hover {
 } 
 
 #events-filters .accordion-button.custom-padding {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding: 0.5rem;
   text-align: left;
 } 
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -4,14 +4,14 @@ description: Community-sourced collection of events and training opportunities r
 cascade:
   header_image: /img/illustrations/navet.jpg
 menu:
-    navbar:
-        identifier: events
-        name: Events & Training
-        weight: 60
-    bottom_community:
-        name: Events & training
-        identifier: events
-        weight: 20
+  navbar:
+    identifier: events
+    name: Events & Training
+    weight: 60
+  bottom_community:
+    name: Events & training
+    identifier: events
+    weight: 20
 ---
 
-This section includes a list of upcoming conferences, webinars, workshops, and training opportunities for Swedish researchers working in the area of data-driven life science. If you know of an appropriate event that is not listed here, please suggest it using the form below. All times are given in Central European Time (CET/CEST). Questions about individual events should be directed to the organisers of that event.
+This section includes a list of events (e.g. workshops and webinars) from SciLifeLab Data Centre. All times are in Central European Time (CET/CEST), unless stated otherwise.

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -80,8 +80,7 @@
     // If no event to show, display appropriate message
     if (eventList.length === 0) {
       eventsHTML = `<div class="alert alert-secondary mt-4">
-                        We are currently unaware of any upcoming events or training opportunities relevant for data-driven 
-                        life science.
+                        There are currently no upcoming events from SciLifeLab Data Centre.
                       </div>`
     } else {
       eventsHTML = `<div class="row mt-3 mb-5">

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -5,513 +5,290 @@
     {{ .Content }}</div>
 </section>
 
-<section>
-  <div class="my-2 text-start">
-    <button type="button" class="btn btn-aqua" data-bs-toggle="modal" data-bs-target="#suggestionModal">
-      Submit an event
-    </button>
-  </div>
-  <div class="modal fade" id="suggestionModal" tabindex="-1" aria-labelledby="suggestionModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <form action="https://forms.dc.scilifelab.se/api/v1/form/B6_setlwEffu0PMR/incoming" class="needs-validation"
-          novalidate method="POST" accept-charset="utf-8">
-          <div class="modal-header">
-            <h5 class="modal-title" id="suggestionModalLabel">Events & training suggestion</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            <div class="">
-              <p>We welcome suggestions for events to be displayed in this section. It can be an event that you are
-                organising or an event that you simply think would be useful to others in the data-driven life science
-                community in Sweden. We primarily aggregate events in Sweden or for a Swedish audience, but submissions
-                about important international events are also welcome.</p>
-              <p>Please fill out at least all obligatory fields (marked with an asterisk) below. The editorial team
-                behind the SciLifeLab Data Platform will then evaluate the suggestion and add relevant events as soon as
-                possible.</p>
-            </div>
-            <div class="mb-3">
-              <label for="event_title" class="form-label fw-bold">Event title:*</label>
-              <input type="text" class="form-control" id="event_title" name="event_title" required>
-            </div>
-            <div class="mb-3">
-              <label for="event_type" class="form-label fw-bold">Event type:*</label>
-              <select class="form-select" id="event_type" name="event_type" required>
-                <option hidden disabled selected value> </option>
-                <option value="conferece">Conference</option>
-                <option value="course">Course</option>
-                <option value="seminar">Seminar</option>
-                <option value="webinar">Webinar</option>
-                <option value="workshop">Workshop</option>
-                <option value="other">Other</option>
-              </select>
-            </div>
-            <div class="mb-3">
-              <label for="event_start_date" class="form-label fw-bold">Event start date:*</label>
-              <input type="date" class="form-control" id="event_start_date" name="event_start_date" required>
-            </div>
-            <div class="mb-3">
-              <label for="event_start_time" class="form-label fw-bold">Event start time:</label>
-              <input type="time" class="form-control" id="event_start_time" name="event_start_time">
-            </div>
-            <div class="mb-3">
-              <label for="event_end_date" class="form-label fw-bold">Event end date:</label>
-              <input type="date" class="form-control" id="event_end_date" name="event_end_date">
-            </div>
-            <div class="mb-3">
-              <label for="event_end_time" class="form-label fw-bold">Event end time:</label>
-              <input type="time" class="form-control" id="event_end_time" name="event_end_time">
-            </div>
-            <div class="mb-3">
-              <label for="venue" class="form-label fw-bold">Venue:</label>
-              <input type="text" class="form-control" id="venue" name="venue">
-              <div class="form-text">For example, "Online event via Zoom" or "Biologihuset, Sölvegatan 35, Lund".</div>
-            </div>
-            <div class="mb-3">
-              <label for="organisers" class="form-label fw-bold">Organiser(s):</label>
-              <input type="text" class="form-control" id="organisers" name="organisers">
-              <div class="form-text">For example, "Swedish National Infrastructure for Computing, SNIC; Chalmers
-                e-commons infrastructure".</div>
-            </div>
-            <div class="mb-3">
-              <label for="event_info_url" class="form-label fw-bold">Event information webpage:*</label>
-              <input type="url" class="form-control" id="event_info_url" name="event_info_url" required>
-              <div class="form-text">Enter URL starting with 'https://...'.</div>
-            </div>
-            <div class="mb-3">
-              <label for="event_registration_url" class="form-label fw-bold">Event registration webpage:</label>
-              <input type="url" class="form-control" id="event_registration_url" name="event_registration_url">
-              <div class="form-text">Enter URL starting with 'https://...'.</div>
-            </div>
-            <div class="mb-3">
-              <label for="event_description" class="form-label fw-bold">Event description:</label>
-              <textarea class="form-control" id="event_description" name="event_description" rows="5"></textarea>
-            </div>
-            <div class="mb-3 form-check fw-bold">
-              <input type="checkbox" class="form-check-input" id="involved_in_organising" name="involved_in_organising">
-              <label class="form-check-label" for="involved_in_organising">I am involved in organising this
-                event.</label>
-            </div>
-            <div class="mb-3">
-              <label for="submitter_name" class="form-label fw-bold">Your name:</label>
-              <input type="text" class="form-control" id="submitter_name" name="submitter_name">
-              <div class="form-text">Enter your name if you agree to be contacted regarding this suggestion (your name
-                will not be shown in the event information).</div>
-            </div>
-            <div class="mb-3">
-              <label for="submitter_email" class="form-label fw-bold">Your contact email:</label>
-              <input type="email" class="form-control" id="submitter_email" name="submitter_email">
-              <div class="form-text">Enter your email address if you agree to be contacted regarding this suggestion
-                (your email will not be displayed in the event information).</div>
-            </div>
-            <div class="g-recaptcha" data-sitekey="6LdPd50fAAAAAJ_dVMXFJjzOTh7XZeAI-ej82GPv"></div>
-            <input type="url" id="originUrl" name="originUrl" value="" hidden aria-label="form-origin-url" />
-            <input type="hidden" name="origin" value="event_training_suggestion" aria-label="form-name" />
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            <button type="submit" class="btn btn-aqua">Submit</button>
-          </div>
-        </form>
-      </div>
+<section id="events-section" style="margin-top: 2.5rem;">
+  <!-- Loading indicator -->
+  <div id="events-loading" class="text-center py-5">
+    <div class="spinner-border text-aqua" role="status" style="width: 3rem; height: 3rem;">
+      <span class="visually-hidden">Loading event...</span>
     </div>
+    <p class="mt-3 text-muted">Loading available events...</p>
   </div>
-</section>
 
-<section id="events-section">
   <!-- The events content will filled by JS function below -->
 </section>
 
 <script>
- // Functions need to be run when the DOM is ready
-  document.addEventListener("DOMContentLoaded", function (event) {
-    // Takes a URL and calls the callback function pass the data fetched
-    function getDataFromUrl(url, load_callback, loadend_callback) {
-      var req = new XMLHttpRequest();
-      req.overrideMimeType("application/json");
-      req.open("GET", url, true);
-      // The function call for fetching data and display
-      req.onload = function () {
-        load_callback(JSON.parse(req.responseText).items);
-      };
-      // The function call for adding filtering
-      req.onloadend = function () {
-        loadend_callback();
-      };
-      req.send(null);
-    }; // function "getDataFromUrl" ends here
-    
-    function addEvents(dataArray) {
-      var eventList = [], local = [], level = [], category = []
-      dataArray.forEach((event) => {
-        // Show only events meant for the platform
-        if (typeof event.target !== 'undefined' && event.target.includes("data-platform")) {
-          // Not insterested if the deadline have already passed
-          event.banner_date = event.date_start || event.registration_deadline;
-          if (typeof event.banner_date !== 'undefined'){
-            var dateString = event.banner_date + (event.time_start ? ' ' + event.time_start : '');
-            var [h, m] = event.time_start ? event.time_start.split(":") : [0, 0];
-            if (new Date(dateString) >= new Date().setHours(h, m)){
-              eventList.push(event);
-              if (typeof event.location !== 'undefined'){
-                event.location.forEach((lc) => {if(!local.includes(lc)){local.push(lc)}});
-              };
-              if (typeof event.category !== 'undefined'){
-                event.category.forEach((ct) => {if(!category.includes(ct)){category.push(ct)}});
-              };
-              if (typeof event.level !== 'undefined'){
-                if(!level.includes(event.level)){level.push(event.level);}
-              };
-            };
-          };
-        };
-      }); // dataArray for each ends here
-      
-      // Sort the arrays
-      eventList = eventList.sort((a,b) => (a.banner_date > b.banner_date) ? 1 : (a.banner_date < b.banner_date) ? -1 : 0);
-      local = local.sort();
-      level = level.sort();
-      category = category.sort();
-      
-      // If no event to show, display appropriate message
-      if (eventList.length === 0) {
-        var eventsHTML = `<div class="alert alert-secondary mt-4">
-                          We are currently unaware of any upcoming events or training opportunities relevant for data-driven 
-                          life science. If you know of any relevant events or training opportunities that should be shown 
-                          here, please suggest them to us using the "Submit an event" button above.
-                        </div>`
-      } else {
-        var eventsHTML = `<div class="row mt-3 mb-5">
-                          <div class="col-lg-2 pe-lg-0" id="events-filters">
-                            <div class="accordion bg-light" id="filterAccordion" style="position: sticky; top: 15px;">
-                              <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingFilters">
-                                  <button class="accordion-button collapsed d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFilters" aria-expanded="false" aria-controls="collapseFilters">
-                                    Filters
-                                  </button>
-                                </h2>
-                                  <div class="filter-heading d-none d-lg-block mb-lg-0">
-                                    <h5>Filters</h5>
-                                  </div>`;
-        if (local.length > 0){
-          eventsHTML += `<div id="collapseFilters" class="accordion-collapse collapse d-lg-block" aria-labelledby="headingFilters">
-                                  <div class="accordion-body">
-                                    <div class="accordion" id="innerAccordion">
-                                      <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingType">
-                                          <button class="accordion-button custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseType" aria-expanded="true" aria-controls="collapseType">
-                                            Location
-                                          </button>
-                                        </h2>
-                                        <div id="collapseType" class="accordion-collapse collapse show" aria-labelledby="headingType">
-                                          <div class="accordion-body">`;
-          local.forEach((lc) => {
-            eventsHTML += `<div class="form-check">   
-                            <input class="form-check-input" type="checkbox" id="${lc}" name="location" value="${lc.replaceAll(" ", "-").toLowerCase()}">
-                            <label class="form-check-label" for="${lc}">${(lc == "Online") ? "Online/Hybrid" : lc}</label>
-                           </div>`;
-          });
-          eventsHTML += `</div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>`;
-        };
-        if (category.length > 0){
-          eventsHTML += `<div id="collapseFilters" class="accordion-collapse collapse d-lg-block" aria-labelledby="headingFilters">
-                                  <div class="accordion-body">
-                                    <div class="accordion" id="innerAccordion">
-                                      <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingCategory">
-                                          <button class="accordion-button collapsed custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseCategory" aria-expanded="true" aria-controls="collapseCategory">
-                                            Category
-                                          </button>
-                                        </h2>
-                                        <div id="collapseCategory" class="accordion-collapse collapse" aria-labelledby="headingCategory">
-                                          <div class="accordion-body">`;
-          category.forEach((ct) => {
-            eventsHTML += `<div class="form-check">   
-                            <input class="form-check-input" type="checkbox" id="${ct}" name="category" value="${ct.replaceAll(" ", "-").toLowerCase()}">
-                            <label class="form-check-label" for="${ct}">${ct}</label>
-                           </div>`;
-          });
-            eventsHTML += `</div>
+  // Fetch events from URL and return relavant data
+  async function getEventsData(url) {
+    try {
+      // Fetch jobs directly from SciLifeLab WordPress API
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const allData = await response.json();
+
+      // Transform jobs to our format
+      const eventsData = [], allTypes = new Set(), allLocations = new Set(); 
+      allData["events"].forEach(event => {
+        // Collect all even types to be used as filter
+        const eventType = event?.categories.map(ct => ct?.name);
+        eventType.forEach(et => allTypes.add(et));
+        // Collect all location to be used as filter
+        const location = event?.venue?.city;
+        allLocations.add(location);
+        // Collect only required data
+        eventsData.push({
+          title: event?.title,
+          type: eventType,
+          date_start: [
+              event?.start_date_details?.year,
+              event?.start_date_details?.month,
+              event?.start_date_details?.day
+            ].join('-'),
+          time_start: [
+              event?.start_date_details?.hour,
+              event?.start_date_details?.minutes
+            ].join(':'),
+          date_end: [
+              event?.end_date_details?.month,
+              event?.end_date_details?.year,
+              event?.end_date_details?.day
+            ].join('-'),
+          time_end: [
+              event?.end_date_details?.hour,
+              event?.end_date_details?.minutes
+            ].join(':'),
+          venue: event?.venue?.venue,
+          location: location,
+          organisers: event?.organizer.map(org => org?.organizer),
+          url: event?.url
+        });
+      });
+      return [eventsData, [...allTypes], [...allLocations]];
+    } catch (error) {
+      console.error('Error fetching events:', error);
+      return [[], [], []]; // Return empty array if API fails
+    }
+  }
+
+  function addEvents(eventList=[], eventTypes=[], eventLocations=[]) {
+    // Sort the arrays
+    eventLocations = eventLocations.sort();
+    eventTypes = eventTypes.sort();
+    let eventsHTML;
+    // If no event to show, display appropriate message
+    if (eventList.length === 0) {
+      eventsHTML = `<div class="alert alert-secondary mt-4">
+                        We are currently unaware of any upcoming events or training opportunities relevant for data-driven 
+                        life science.
+                      </div>`
+    } else {
+      eventsHTML = `<div class="row mt-3 mb-5">
+                        <div class="col-lg-2 pe-lg-0" id="events-filters">
+                          <div class="accordion bg-light" id="filterAccordion" style="position: sticky; top: 15px;">
+                            <div class="accordion-item">
+                              <h2 class="accordion-header" id="headingFilters">
+                                <button class="accordion-button collapsed d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFilters" aria-expanded="false" aria-controls="collapseFilters">
+                                  Filters
+                                </button>
+                              </h2>
+                              <div class="filter-heading d-none d-lg-block mb-lg-0">
+                                <h5>Filters</h5>
                               </div>
+                              <div id="collapseFilters" class="accordion-collapse collapse d-lg-block" aria-labelledby="headingFilters">
+                                <div class="accordion-body px-3 px-lg-2 ms-1 ms-lg-0">`;
+      if (eventLocations.length){
+        eventsHTML += `<div class="accordion-item border-0 mt-2">
+                            <div class="accordion-header d-none d-lg-block" id="headingType">
+                              <button class="accordion-button custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLocation" aria-expanded="true" aria-controls="collapseLocation">
+                                Location
+                              </button>
                             </div>
-                          </div>
-                        </div>`;
-        };
-        if (level.length > 0){
-          eventsHTML += `<div id="collapseFilters" class="accordion-collapse collapse d-lg-block" aria-labelledby="headingFilters">
-                                  <div class="accordion-body">
-                                    <div class="accordion" id="innerAccordion">
-                                      <div class="accordion-item">
-                                        <h2 class="accordion-header" id="headingLevel">
-                                          <button class="accordion-button collapsed custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLevel" aria-expanded="true" aria-controls="collapseLevel">
-                                            Level
-                                          </button>
-                                        </h2>
-                                        <div id="collapseLevel" class="accordion-collapse collapse" aria-labelledby="headingLevel">
-                                          <div class="accordion-body">`;
-          level.forEach((lv) => {
-            eventsHTML += `<div class="form-check">   
-                            <input class="form-check-input" type="checkbox" id="${lv}" name="level" value="${lv.replaceAll(" ", "-").toLowerCase()}">
-                            <label class="form-check-label" for="${lv}">${lv}</label>
-                           </div>`;
-          });
-          eventsHTML += `</div>
-                        </div>
-                      </div>`;
-        };
+                            <h5 class="d-lg-none">Location</h5>
+                            <div id="collapseLocation" class="accordion-collapse collapse show" aria-labelledby="headingType">
+                              <div class="accordion-body">`;
+        eventLocations.forEach((lc) => {
+          eventsHTML += `<div class="form-check">   
+                          <input class="form-check-input" type="checkbox" id="${lc}" name="location" value="${lc.replaceAll(" ", "-").toLowerCase()}">
+                          <label class="form-check-label" for="${lc}">${(lc == "Online") ? "Online/Hybrid" : lc}</label>
+                          </div>`;
+        });
         eventsHTML += `</div>
+                      </div>
+                    </div>`;
+      };
+      if (eventTypes.length){
+        eventsHTML += `<div class="accordion-item border-0 mt-2">
+                            <div class="accordion-header d-none d-lg-block" id="headingType">
+                              <button class="accordion-button custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseType" aria-expanded="true" aria-controls="collapseType">
+                                Type
+                              </button>
+                            </div>
+                            <h5 class="d-lg-none">Type</h5>
+                            <div id="collapseType" class="accordion-collapse collapse show" aria-labelledby="headingType">
+                              <div class="accordion-body">`;
+        eventTypes.forEach((tp) => {
+          eventsHTML += `<div class="form-check">   
+                          <input class="form-check-input" type="checkbox" id="${tp}" name="type" value="${tp.replaceAll(" ", "-").toLowerCase()}">
+                          <label class="form-check-label" for="${tp}">${tp}</label>
+                          </div>`;
+        });
+          eventsHTML += `</div>
                         </div>
+                      </div>`;
+      };
+      eventsHTML += `</div>
                       </div>
                       </div>
                       </div>
-                       <div class="col-lg mt-2 mt-lg-0">
-                         <div class="row g-2" id="events-container">`;
-        eventList.forEach((event, ind) => {
-          var this_event_local, this_event_category, this_event_level;
-          var event_date = new Date(event.banner_date);
-          if (typeof event.location !== 'undefined'){
-            this_event_local = event.location.map(lc => lc.replaceAll(" ", "-").toLowerCase()).join(" ");
-          };
-          if (typeof event.category !== 'undefined'){
-            this_event_category = event.category.map(ct => ct.replaceAll(" ", "-").toLowerCase()).join(" ");
-          };
-          if (typeof event.level !== 'undefined'){
-            this_event_level = event.level.replaceAll(" ", "-").toLowerCase();
-          };
-          eventsHTML += `<div class="col-md-6 col-lg-4 event" data-event-location="${this_event_local}"
-                          data-event-category="${this_event_category}" data-event-level="${this_event_level}">
-                          <div class="card-box">
-                            <div class="d-flex justify-content-between">
-                              <div>
-                                <span class="badge event-type mb-1">${event.type}</span>
-                                <h5><a class="" role="button" data-bs-toggle="modal"
-                                    data-bs-target="#descriptionModal${ind}">${event.title}</a></h5>
-                              </div>
-                              <div>
-                                <div class="px-2 pb-1 m-2 d-flex flex-column rounded event-date">
+                    </div>
+                      <div class="col-lg mt-2 mt-lg-0">
+                        <div class="row g-2" id="events-container">`;
+      eventList.forEach((event, ind) => {
+        let this_event_local, this_event_type;
+        const event_date = new Date(event.date_start);
+        if (typeof event.location !== 'undefined'){
+          this_event_local = event.location.replaceAll(" ", "-").toLowerCase();
+        };
+        if (typeof event.type !== 'undefined'){
+          this_event_type = event.type.map(tp => tp.replaceAll(" ", "-").toLowerCase()).join(" ");
+        };
+        eventsHTML += `<div class="col-md-6 col-lg-4 event" data-event-location="${this_event_local}"
+                        data-event-type="${this_event_type}">
+                        <div class="card-box">
+                          <div class="d-flex justify-content-between">
+                            <div>`
+        event.type.forEach(tp => {
+          eventsHTML += `<span class="badge event-type mb-1">${tp}</span>`
+        })
+        eventsHTML += `<h5><a target="_blank" href="${event.url}">${event.title}</a></h5>
+                            </div>
+                            <div>
+                              <div class="px-2 pb-1 m-2 d-flex flex-column rounded event-date">
                                 <div class="px-2 fs-3 mx-auto">${event_date.getDate()}</div>
                                 <div class="pb-1 px-2 mx-auto">${event_date.toLocaleString('default', {'month': 'long'})}</div>
-                                </div>
                               </div>
-                            </div>`;
-          var event_date_time = [], date_format_options = {'month': 'short', day:'numeric', year: 'numeric'};
-          event.date_start && event_date_time.push(new Date(event.date_start).toLocaleString('en-US', date_format_options));
-          event.time_start && event_date_time.push(event.time_start);
-          (event.date_end || event.time_end) && event_date_time.push("-")
-          event.date_end && event_date_time.push(new Date(event.date_end).toLocaleString('en-US', date_format_options));
-          event.time_end && event_date_time.push(event.time_end);
-          if (event_date_time.length > 0){
-            eventsHTML += `<div class="row mt-3">
-                             <div class="col">
-                               <b>Date and time:</b> ${event_date_time.join(" ")}
-                             </div>
-                           </div>`;
-          }
-          if (event.registration_deadline){
-            eventsHTML += `<div class="row mt-1">
-                             <div class="col">
-                               <b>Registration deadline:</b> ${new Date(event.registration_deadline).toLocaleString('en-US', date_format_options)}
-                             </div>
-                           </div>`;
-          }
-          if (event.organisers){
-            eventsHTML += `<div class="row">
-                             <div class="col">
-                               <b>Organiser(s):</b> ${event.organisers}
-                             </div>
-                           </div>`;
-          }
-          if (event.venue){
-            eventsHTML += `<div class="row">
-                             <div class="col">
-                               <b>Venue:</b> ${event.venue}
-                             </div>
-                           </div>`;
-          }
-          eventsHTML += `<div class="row mt-3">
-                          <div class="col">
-                            <button type="button" class="btn btn-details btn-sm" data-bs-toggle="modal"
-                              data-bs-target="#descriptionModal${ind}">
-                              See details
-                            </button>
-                            <div class="modal fade" id="descriptionModal${ind}" tabindex="-1"
-                              aria-labelledby="descriptionModalLabel${ind}" aria-hidden="true">
-                              <div class="modal-dialog">
-                                <div class="modal-content">
-                                  <div class="modal-header">
-                                    <h5 class="modal-title" id="descriptionModalLabel${ind}">${event.title}</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                  </div>
-                                  <div class="modal-body">
-                                    <div class="row">
-                                      <div class="col">
-                                        <b>Event type:</b> <span class="badge event-type mb-1">${event.type}</span>
-                                      </div>
-                                    </div>`;
-          if (event_date_time.length > 0){
-            eventsHTML += `<div class="row mt-1">
-                             <div class="col">
-                               <b>Date and time:</b> ${event_date_time.join(" ")}
-                             </div>
-                           </div>`;
-          }
-          if (event.registration_deadline){
-            eventsHTML += `<div class="row mt-1">
-                             <div class="col">
-                               <b>Registration deadline:</b> ${new Date(event.registration_deadline).toLocaleString('en-US', date_format_options)}
-                             </div>
-                           </div>`;
-          }
-          if (event.organisers){
-            eventsHTML += `<div class="row mt-1">
-                             <div class="col">
-                               <b>Organiser(s):</b> ${event.organisers}
-                             </div>
-                           </div>`;
-          }
-          if (event.venue){
-            eventsHTML += `<div class="row mt-1">
-                             <div class="col">
-                               <b>Venue:</b> ${event.venue}
-                             </div>
-                           </div>`;
-          }
-          if (event.description){
-            eventsHTML += `<div class="row mt-3">
-                             <div class="col">
-                               <b>Description:</b><br> ${event.description}
-                             </div>
-                           </div>`;
-          }
-          eventsHTML += `<div class="row mt-3">
-                          <p>For more information, see the event webpage at the link below.</p>
-                          <div class="col-md">
-                            <a target="_blank" href="${event.event_url}"><i class="bi bi-globe"></i> Event webpage</a>
+                            </div>
                           </div>`;
-          if (event.registration_url){
-            eventsHTML += `<div class="col-md">
-                            <a target="_blank" href="${event.registration_url}"><i class="bi bi-globe"></i>
-                              Registration</a>
+        var event_date_time = [], date_format_options = {'month': 'short', day:'numeric', year: 'numeric'};
+        event.date_start && event_date_time.push(new Date(event.date_start).toLocaleString('en-US', date_format_options));
+        event.time_start && event_date_time.push(event.time_start);
+        (event.date_end || event.time_end) && event_date_time.push("-")
+        event.date_end && event_date_time.push(new Date(event.date_end).toLocaleString('en-US', date_format_options));
+        event.time_end && event_date_time.push(event.time_end);
+        if (event_date_time.length > 0){
+          eventsHTML += `<div class="row mt-3">
+                            <div class="col">
+                              <b>Date and time:</b> ${event_date_time.join(" ")}
+                            </div>
                           </div>`;
-          }
-          eventsHTML += `</div>
+        }
+        if (event.organisers){
+          const organisers = event.organisers.join(", ")
+          eventsHTML += `<div class="row">
+                            <div class="col">
+                              <b>Organiser(s):</b> ${organisers}
+                            </div>
+                          </div>`;
+        }
+        if (event.venue){
+          eventsHTML += `<div class="row">
+                            <div class="col">
+                              <b>Venue:</b> ${event.venue}
+                            </div>
+                          </div>`;
+        }
+        eventsHTML += `<div class="row mt-3">
+                        <div class="col">
+                          <a class="btn btn-details btn-sm" target="_blank" href="${event.url}">
+                            <i class="bi bi-globe"></i> See details
+                          </a>
+                        </div>
+                       </div>
                       </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                      </div>
-                    </div>
+                    </div>`;
+      }); // for each events iteration to create html ends here
+      eventsHTML += `<div id="no-filtered-events" class="mt-4" style="display:none;">
+                    <p class="text-center">No events found for selected criteria.</p>
+                  </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>`;
-        }); // for each events iteration to create html ends here
-        eventsHTML += `<div id="no-filtered-events" style="display:none;">
-                      <p class="text-center">No events found for selected criteria.</p>
-                    </div>
-                    </div>
-                  </div>
-                </div>`;
-        
-      }; // Creating of events display html ends here
+              </div>`;
       
-      var eventsSection = document.getElementById('events-section');
-      eventsSection.innerHTML = eventsHTML;
-    }; // function "addEvents" ends here
+    }; // Creating of events display html ends here
     
-    function enableFiltering (){
-      // Filter jobs based on selected criteria
-      $('div#events-filters input:checkbox').on('change', function () {
-        var selected_filters = new Object();
+    // Hide loading indicator
+    const loadingElement = document.getElementById('events-loading');
+    if (loadingElement) {
+      loadingElement.style.display = 'none';
+    }
 
-        // Collect and create a list with selected values
-        var event_location = $('input:checkbox[name="location"]:checked').map(function () { return this.value }).get();
-        if (event_location.length) { selected_filters['data-event-location'] = event_location };
+    // Display collected events or relevant message if not events
+    var eventsSection = document.getElementById('events-section');
+    eventsSection.innerHTML = eventsHTML;
 
-        var event_category = $('input:checkbox[name="category"]:checked').map(function () { return this.value }).get();
-        if (event_category.length) { selected_filters['data-event-category'] = event_category };
-
-        var event_level = $('input:checkbox[name="level"]:checked').map(function () { return this.value }).get();
-        if (event_level.length) { selected_filters['data-event-level'] = event_level };
-
-        // Hide all displayed jobs and message
-        $('div#events-container div.event').hide();
-        $('div#no-filtered-events').hide();
-
-        // Show relavant jobs based on selected criteria
-        if (!Object.keys(selected_filters).length) {
-          $('div#events-container div.event').show();
-        } else {
-          var all_selected_events = [];
-          // Iterate over all selected criteria and collect the events
-          for (var [filter_name, filter_list] of Object.entries(selected_filters)) {
-            var s_events = new Set;
-            filter_list.forEach(function (filter_value) {
-              $(`div#events-container div[${filter_name}*='${filter_value}']`).each(function () { s_events.add(this); });
-            });
-            all_selected_events.push(s_events);
-          };
-          // When multiple criteria selectd it should act as AND not OR
-          selected_events = all_selected_events.reduce(function (x, y) {
-            var z = new Set;
-            x.forEach(v => y.has(v) && z.add(v));
-            return z;
-          });
-          // Set display for event with selected criteria
-          if (selected_events.size) {
-            selected_events.forEach(function (sEvent) { sEvent.style.display = ''; })
-          } else {
-            // Display a message if no events available for selected criteria
-            $('div#no-filtered-events').show();
-          };
-        };
-
-        // Bring the events section top to the veiwport if it isn't
-        var tab_top = document.querySelector("section#events-section").getBoundingClientRect().top;
-        if (tab_top < 0){ $("html").scrollTop(window.pageYOffset + tab_top - 60); }
-
-      }); // Checkbox "on change" trigger ends here
     
-    }; // function "enableFiltering" ends here
+  }; // function "addEvents" ends here
     
-    // Call the function to fetch, parse and display events
-    getDataFromUrl(
-      decodeURIComponent("https%3A%2F%2Fblobserver.dc.scilifelab.se%2Fblob%2Fddls_events.json"),
-      addEvents,
-      enableFiltering
-    );
-    
-    // Events suggestion form related function
-    // set origin url in the form
-    document.getElementById('originUrl').value = location.href;
+  function enableFiltering (){
+    // Filter jobs based on selected criteria
+    $('div#events-filters input:checkbox').on('change', function () {
+      var selected_filters = new Object();
 
-    // Validate the form by checking mandatory fields and recaptcha
-    var form = document.querySelector('.needs-validation');
-    form.addEventListener('submit', function (event) {
-      if (form.checkValidity() === false) {
-        event.preventDefault();
-        alert("Please fill out all required fields.");
-        event.stopPropagation();
-        form.classList.add('was-validated')
-      }
-      var recaptcha = $("#g-recaptcha-response").val();
-      if (recaptcha === "") {
-        event.preventDefault();
-        alert("Please tick 'I'm not a robot' above the 'Submit the form' button.");
-      }
-    }); // Forms validation block ends here
+      // Collect and create a list with selected values
+      const checkLocations = $('input:checkbox[name="location"]:checked').map(function () { return this.value }).get();
+      const checkTypes = $('input:checkbox[name="type"]:checked').map(function () { return this.value }).get();
 
-    // Add aria-label for code generated by recaptcha
-    window.addEventListener("load", function () {
-      $('textarea#g-recaptcha-response').attr('aria-label', "The recaptcha response will appear here");
-    });
-    
-  }); // Document "DOMContentLoaded" trigger ends here
+      // Events and No filtered message
+      const $events = $('div#events-container div.event');
+      const $noFilteredEvents = $('div#no-filtered-events');
+
+      // Hide all displayed jobs and message
+      $events.hide();
+      $noFilteredEvents.hide();
+
+      // Show relavant jobs based on selected criteria
+      if (!checkLocations.length && !checkTypes.length) {
+        $events.show();
+      } else {
+        $events.each(function() {
+          const $event = $(this);
+          const eventType = $event.data("event-type");
+          const eventLocation = $event.data("event-location");
+          let showEvent = true;
+          // See if any relevant type selected
+          if (checkTypes.length) {
+            showEvent = showEvent && eventType.split(" ").some(tp => checkTypes.includes(tp));
+          }
+          // See if any relevant location selected
+          if (checkLocations.length) {
+            showEvent = showEvent && checkLocations.includes(eventLocation);
+          }
+          // Show event if relevant
+          if (showEvent) {
+            $event.show();
+          }
+        });
+        // Display relevant message if no event visible after filter
+        const visibleEvents = $events.filter(":visible");
+        if (!visibleEvents.length) {
+          $noFilteredEvents.show()
+        }
+      };
+
+      // Bring the events section top to the veiwport if it isn't
+      var tab_top = document.querySelector("section#events-section").getBoundingClientRect().top;
+      if (tab_top < 0){ $("html").scrollTop(window.pageYOffset + tab_top - 60); }
+    }); // Checkbox "on change" trigger ends here
+  }; // function "enableFiltering" ends here
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    // Fetch event and populate
+    const allEventsData = await getEventsData(decodeURIComponent("https%3A%2F%2Fwww.scilifelab.se%2Fwp-json%2Ftribe%2Fevents%2Fv1%2Fevents%3Ftags%3D7989"));
+    await addEvents(eventList=allEventsData[0], eventTypes=allEventsData[1], eventLocations=allEventsData[2]);
+    enableFiltering();
+  });
 </script>
 
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -250,48 +250,38 @@
     
     // Creates html entry for latest events
     function addEvents(data){
-      var dataArray = data.items, eventList = [], eventsHTML = "";;
-      dataArray.forEach((event) => {
-        if (typeof event.target !== 'undefined' && event.target.includes("data-platform")) {
-          event.banner_date = event.date_start || event.registration_deadline;
-          if (typeof event.banner_date !== 'undefined'){
-            var dateString = event.banner_date + (event.time_start ? ' ' + event.time_start : '');
-            var [h, m] = event.time_start ? event.time_start.split(":") : [0, 0];
-            if (new Date(dateString) >= new Date().setHours(h, m)){
-              eventList.push(event);
-            };
-          };
-        };
-      });
-      eventList = eventList.sort((a,b) => (a.banner_date > b.banner_date) ? 1 : (a.banner_date < b.banner_date) ? -1 : 0);
-      var eventsToShow = eventList.slice(0, 2);
-      if (eventsToShow.length > 0){
-        var eventsHTML = `<div class="border rounded my-4 pb-2">
+      let eventList = data?.events;
+      let eventsHTML = `<div class="border rounded my-4 pb-2">
                             <div class="d-flex justify-content-between align-items-center px-3 py-2 mb-1 bg-home-events-title">
-                              <h4 class="mb-1">Upcoming Events</h4>
-                              <a href="/events/">See all events <i class="bi bi-arrow-right-square-fill"></i></a>
-                            </div>
-                            <div>`;
-        eventsToShow.forEach((event, ind) => {
-          var event_date = new Date(event.banner_date);
+                              <h4 class="mb-1">Upcoming Events</h4>`;
+      if (eventList.length > 0){
+        eventsHTML += `<a href="/events/">See all events <i class="bi bi-arrow-right-square-fill"></i></a>`;
+      }
+      eventsHTML += `</div>
+                      <div>`;
+      if (eventList.length > 0){
+        eventList.forEach((event, ind) => {
+          let event_date = new Date(event.start_date);
           eventsHTML += `<div class="d-flex justify-content-between align-items-center px-3 py-2">
-                          <a class="" role="button" href="/events/" target="_blank">${event.title}</a>
+                          <a class="" role="button" href="${event.url}" target="_blank">${event.title}</a>
                           <div class="px-2 py-1 d-flex flex-column rounded event-date mw-100">
                             <div class="px-2 fs-6 mx-auto">${event_date.getDate().toString().padStart(2, '0')}</div>
                             <div class="pb-1 px-2 fs-6 mx-auto">${event_date.toLocaleString('en-US', { 'month': 'short' })}</div>
                           </div>
                          </div>
-                        ${ind < (eventsToShow.length - 1) ? '<div class="px-4 py-1"><hr class="my-2"></div>' : ''}`;
+                        ${ind < (eventList.length - 1) ? '<div class="px-4 py-1"><hr class="my-2"></div>' : ''}`;
         }); // for each events iteration to create html ends here
-        eventsHTML += `</div>
-                    </div>`;
+      } else {
+        eventsHTML += `<div class="px-3 py-2">No upcoming Data Centre events</div>`;
+      }
+      eventsHTML += `</div>
+                  </div>`;
       var eventRow = document.getElementById('upcoming-events');
       eventRow.innerHTML = eventsHTML;
-      };
     }
     
     getDataFromUrl(
-      decodeURIComponent("https%3A%2F%2Fblobserver.dc.scilifelab.se%2Fblob%2Fddls_events.json"),
+      decodeURIComponent("https%3A%2F%2Fwww.scilifelab.se%2Fwp-json%2Ftribe%2Fevents%2Fv1%2Fevents%3Ftags%3D7989%26per_page%3D2"),
       addEvents
     );
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
         {{ if in .target "researchers" }}
         <div class="col">
           <div class="card-teal-25">
-            <div {{ if .thumbnail_border }}class="p-1" {{ end }}>
+            <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
               <a target="_self" href="{{ .url }}"><img class="img-fluid"
                   src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/service_thumbnails/scilifelab.jpg" }}{{ end }}"
                   alt="{{ .name }}"></a>
@@ -50,7 +50,7 @@
         {{ range first 3 .Site.Data.resources }}
         <div class="col">
           <div class="card-teal-25">
-            <div {{ if .thumbnail_border }}class="p-1" {{ end }}>
+            <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
               <a target="_self" href="{{ .url }}"><img class="img-fluid"
                   src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/resource_thumbnails/scilifelab.jpg" }}{{ end }}"
                   alt="{{ .name }}"></a>

--- a/layouts/resources/data_source.html
+++ b/layouts/resources/data_source.html
@@ -68,7 +68,7 @@
                     </div>
                   </div>
 
-                  <div class="accordion-item">
+                  <div class="accordion-item mt-2">
                     <h2 class="accordion-header" id="headingDataType">
                       <button class="accordion-button collapsed custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseDataType" aria-expanded="false" aria-controls="collapseDataType">
                         Data Type
@@ -86,7 +86,7 @@
                     </div>
                   </div>
 
-                  <div class="accordion-item">
+                  <div class="accordion-item mt-2">
                     <h2 class="accordion-header" id="headingScientificArea">
                       <button class="accordion-button collapsed custom-padding" type="button" data-bs-toggle="collapse" data-bs-target="#collapseScientificArea" aria-expanded="false" aria-controls="collapseScientificArea">
                         Scientific Area

--- a/layouts/resources/data_source.html
+++ b/layouts/resources/data_source.html
@@ -120,7 +120,7 @@
             data-sdata="{{ delimit (apply .data "urlize" ".") ":" }}"
             {{ with .search_tags }}data-search-tags="{{ delimit . ":" | lower }}"{{ end }}>
           <div class="card-teal-25">
-            <div {{ if .thumbnail_border }}class="p-1" {{ end }}>
+            <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
               <a target="_self" href="{{ .url }}"><img class="img-fluid"
                   src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/service_thumbnails/scilifelab.jpg" }}{{ end }}"
                   alt="{{ .name }}"></a>

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -19,7 +19,7 @@
   {{ range sort $resources "name" }}
   <div class="col-md-6 col-lg-4 resource" {{ with .search_tags }}data-search-tags="{{ delimit . ":" | lower }}"{{ end }}>
     <div class="card-teal-25">
-      <div {{ if .thumbnail_border }}class="p-1" {{ end }}>
+      <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
         <a target="_self" href="{{ .url }}"><img class="img-fluid"
             src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/resource_thumbnails/scilifelab.jpg" }}{{ end }}"
             alt="{{ .name }}"></a>

--- a/layouts/services/list.html
+++ b/layouts/services/list.html
@@ -78,7 +78,7 @@
           <div class="col-md-6 col-lg-4 service" data-stype="{{ delimit (apply .type "urlize" ".") " " }}"
                {{ with .search_tags }}data-search-tags="{{ delimit . ":" | lower }}"{{ end }}>
             <div class="card-teal-25">
-              <div {{ if .thumbnail_border }}class="p-1" {{ end }}>
+              <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
                 <a target="_self" href="{{ .url }}"><img class="img-fluid"
                     src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/service_thumbnails/scilifelab.jpg" }}{{ end }}"
                     alt="{{ .name }}"></a>


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR change the events page (and section of homepage) to show only events arranged by Data centre. Using JS we can use `scilifelab API` to directly fetch events and display.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Modified `layout/events/list.html` to show only DC events from scilifelab
- Modified `layout/index.html` to show only upcoming DC events in homepage
- Some minor styling tweaks 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
It seems like a big change in `layout/events/list.html` mostly because of the deletions. The suggestion form and the 'modal' layout is removed. So it might be easier to review the code by pulling the branch locally than trying to do it `Gtihub`

 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1428]
