### PR TITLE
Fix front matter format

### DIFF
--- a/content/highlights/FunCoup6.md
+++ b/content/highlights/FunCoup6.md
@@ -1,5 +1,5 @@
 ---
-title: FunCoup 6: Large-scale functional association networks with regulatory links and integrated tools
+title: "FunCoup 6: Large-scale functional association networks with regulatory links and integrated tools"
 date: 2025-10-16
 summary: FunCoup 6 bridges the gap between functional association and regulatory networks across many organisms, enabling users to explore regulation and module-level insights in a unified framework.
 banner: /highlights/FunCoup6_small.png

--- a/content/news/2025-10-16.md
+++ b/content/news/2025-10-16.md
@@ -1,5 +1,5 @@
 ---
-title: New data highlight on FunCoup 6: Large-scale functional association networks with regulatory links and integrated tools
+title: "New data highlight on FunCoup 6: Large-scale functional association networks with regulatory links and integrated tools"
 date: 2025-10-16
 thumbnail: "/img/news/FunCoup.png"
 caption: "Graphical abstract of FunCoup 6 from [Buzzao et al.](https://doi.org/10.1093/nar/gkae1021)"


### PR DESCRIPTION
Front matter is in `yaml` format, meaning `:` has special meaning. So if a variable value has `:`, it should be wrapped in quotes like `"..."`.