### PR TITLE
Bump tar-fs from 3.1.0 to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "glob": "^11.0.3",
     "pa11y": "^8.0.0",
-    "glob": "^11.0.3"
+    "tar-fs": "^3.1.1"
   },
   "scripts": {
     "validateJson": "node scripts/test-json-schemas.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       pa11y:
         specifier: ^8.0.0
         version: 8.0.0
+      tar-fs:
+        specifier: ^3.1.1
+        version: 3.1.1
 
 packages:
 
@@ -501,6 +504,7 @@ packages:
   puppeteer@22.15.0:
     resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
     engines: {node: '>=18'}
+    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   require-directory@2.1.1:
@@ -573,8 +577,8 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
 
-  tar-fs@3.1.0:
-    resolution: {integrity: sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==}
+  tar-fs@3.1.1:
+    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -689,7 +693,7 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.6.3
-      tar-fs: 3.1.0
+      tar-fs: 3.1.1
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -1227,7 +1231,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.1.0
 
-  tar-fs@3.1.0:
+  tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
       tar-stream: 3.1.7


### PR DESCRIPTION
### 📋 Summary
This PR attempts to solve the following security alerts: 
- https://github.com/ScilifelabDataCentre/data.scilifelab.se/security/code-scanning/189
 
### 🛠️ Changes Made
Updated package.json and the lockfile with pnpm. 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1890](https://scilifelab.atlassian.net/browse/FREYA-1890)
