### PR TITLE
FREYA-1890: Bump libpng

### DIFF
--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -40,7 +40,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-cron

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
 # Use alpine Linux, download desired version of HUGO and build html files
 FROM alpine:3.21 AS build
-RUN apk add --no-cache wget
+RUN apk add --no-cache wget "libpng>=1.6.53-r0"
 ARG HUGO_VERSION="0.147.3"
 ARG HUGO_ENV_ARG
 WORKDIR /src

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
 # Use alpine Linux, download desired version of HUGO and build html files
 FROM alpine:3.21 AS build
-RUN apk update && apk upgrade --no-cache
+RUN apk update && apk upgrade
 RUN apk add --no-cache wget
 ARG HUGO_VERSION="0.147.3"
 ARG HUGO_ENV_ARG

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,6 +1,7 @@
 # Use alpine Linux, download desired version of HUGO and build html files
 FROM alpine:3.21 AS build
-RUN apk add --no-cache wget "libpng>=1.6.53-r0"
+RUN apk update && apk upgrade --no-cache
+RUN apk add --no-cache wget
 ARG HUGO_VERSION="0.147.3"
 ARG HUGO_ENV_ARG
 WORKDIR /src


### PR DESCRIPTION
### 📋 Summary
This PR attempts to fix https://github.com/ScilifelabDataCentre/data.scilifelab.se/security/code-scanning/212 

### 🛠️ Changes Made
- Bump codeql action to fix warning regarding `v3`
- Update and upgrade packages in container

### 🔍 Notes for Reviewers
- An alternative would be to explicitly add a minimum libpng version after `wget`
- The alpine image we have should already have the fixed version of libpng available, we just need to redeploy and upgrade it  
- This might also fix e.g. https://github.com/ScilifelabDataCentre/data.scilifelab.se/security/code-scanning/206 but if not I'll make a new PR to fix that too

### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1890](https://scilifelab.atlassian.net/browse/FREYA-1890)
