### PR TITLE
Add 2026 Open Science events that are external to SciLifeLab

### DIFF
--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -264,4 +264,3 @@
         "description": "A meeting for the Swedish National Data Service (SND) community to connect, share updates and explore topics related to research data management and collaboration."
     }
 ]
-

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -264,3 +264,4 @@
         "description": "A meeting for the Swedish National Data Service (SND) community to connect, share updates and explore topics related to research data management and collaboration."
     }
 ]
+

--- a/data/open_science/events.json
+++ b/data/open_science/events.json
@@ -154,5 +154,113 @@
         "organisers": "",
         "event_url": "https://www.staff.lu.se/calendar/welcome-lu-open-science-days-2025",
         "description": "A two-day event at Lund University exploring how open science can foster trust, transparency and accountability in research, featuring discussions on topics like reproducibility, preprints, and indigenous knowledge. This lunch-to-lunch event, held at Palaestra in Lund, Sweden, is open to Lund University-affiliated researchers, PhD students and support staff, with limited spots for external participants."
+    }, 
+    {
+        "title": "FAIR play: Mastering Metadata to Empower Life Scientists",
+        "type": "Event",
+        "date_start": "2025-11-25",
+        "time_start": "11:00",
+        "date_end": "",
+        "time_end": "12:00",
+        "venue": "Virtual Event",
+        "organisers": "",
+        "event_url": "https://www.scilifelab.se/event/openscience-fair/",
+        "description": "A seminar hosted by SciLifeLab’s Data Centre and NBIS focused on open science and research-data management, offering life scientists practical insights and discussion around metadata, FAIR data practices, sharing strategies and reproducibility."
+    }, 
+    {
+        "title": "CoARA National Chapter Sweden: Nationell konferens 2025",
+        "type": "Event",
+        "date_start": "2025-12-05",
+        "time_start": "09:30",
+        "date_end": "",
+        "time_end": "12:00",
+        "venue": "Virtual Event",
+        "organisers": "",
+        "event_url": "https://suhf.se/aktiviteter/coara-national-chapter-sweden-nationell-konferens-2025/",
+        "description": "A virtual conference hosted by Sweden’s CoARA National Chapter, bringing together researchers, funders and institutions to discuss current initiatives and working-group efforts to reform research assessment."
+    },
+    {
+        "title": "SBDI Days 2026: Artificial Intelligence in Ecology and Biodiversity Research",
+        "type": "Event",
+        "date_start": "2026-02-10",
+        "time_start": "",
+        "date_end": "2026-02-11",
+        "time_end": "",
+        "venue": "Stockholm, Sweden",
+        "organisers": "",
+        "event_url": "https://lyyti.events/p/SBDI_Days_2026__Artificial_Intelligence_in_Ecology_and_Biodiversity_Research_9077",
+        "description": "A meeting hosted by the Swedish Biodiversity Data Infrastructure that brings together researchers in ecology, biodiversity, remote sensing and data science to explore how AI and machine learning are transforming biodiversity research, monitoring and conservation."
+    },
+    {
+        "title": "Open Research Week 2026",
+        "type": "Event",
+        "date_start": "2026-03-02",
+        "time_start": "",
+        "date_end": "2026-03-06",
+        "time_end": "",
+        "venue": "Online",
+        "organisers": "",
+        "event_url": "https://www.liverpool.ac.uk/open-research/open-research-week-2026/",
+        "description": "An event series that celebrates and promotes open research for researchers and colleagues who support open research. Whilst some sessions are UK-focused, others will be of interest to colleagues around the world."
+    },
+     {
+        "title": "KubeCon + CloudNativeCon Europe 2026",
+        "type": "Event",
+        "date_start": "2026-03-23",
+        "time_start": "",
+        "date_end": "2026-03-26",
+        "time_end": "",
+        "venue": "Amsterdam, The Netherlands",
+        "organisers": "",
+        "event_url": "https://openssf.org/event/kubecon-cloudnativecon-europe-2026/#:~:text=KubeCon%20%2B%20CloudNativeCon%20brings%20together%20adopters,from%2023%E2%80%9326%20March%202026.",
+        "description": "A Cloud Native Computing Foundation conference bringing together developers and adopters to share practical experiences and developments around Kubernetes and cloud-native technologies."
+    },
+    {
+        "title": "SND Network meeting in Gothenburg 21–22 April 2026",
+        "type": "Event",
+        "date_start": "2026-04-21",
+        "time_start": "",
+        "date_end": "2026-04-22",
+        "time_end": "",
+        "venue": "Gothenburg, Sweden",
+        "organisers": "",
+        "event_url": "https://snd.se/sv/natverkstraff-i-goteborg-21-22-april-2026",
+        "description": "A meeting for the Swedish National Data Service (SND) community to connect, share updates and explore topics related to research data management and collaboration."
+    },
+    {
+        "title": "FORCE11: To Go Far, Go Together: Advancing Scholarly Communication Across Boundaries and Disruptions",
+        "type": "Event",
+        "date_start": "2026-06-03",
+        "time_start": "",
+        "date_end": "2026-06-05",
+        "time_end": "",
+        "venue": "Singapore",
+        "organisers": "",
+        "event_url": "https://force11.org/force2026/",
+        "description": "An international conference by FORCE11 that brings together researchers, publishers, librarians, funders and technologists to advance and tackle challenges in scholarly communication, open science and research dissemination."
+    },
+    {
+        "title": "Nordic-RSE in person conference 2026",
+        "type": "Event",
+        "date_start": "2026-06-09",
+        "time_start": "",
+        "date_end": "2026-06-10",
+        "time_end": "",
+        "venue": "Tromsø, Norway",
+        "organisers": "",
+        "event_url": "https://nordic-rse.org/events/2026-in-person-conference/",
+        "description": "A conference for the Nordic-RSE community that brings together research software engineers, developers and related professionals to share practical experiences, tools and practices for research software development and to foster knowledge exchange within the field."
+    },
+    {
+        "title": "SND Network meeting in Eskilstuna 21–22 October 2026",
+        "type": "Event",
+        "date_start": "2026-10-21",
+        "time_start": "",
+        "date_end": "2026-10-22",
+        "time_end": "",
+        "venue": "Eskilstuna, Sweden",
+        "organisers": "",
+        "event_url": "https://snd.se/sv/natverkstraff-i-eskilstuna-21-22-oktober-2026",
+        "description": "A meeting for the Swedish National Data Service (SND) community to connect, share updates and explore topics related to research data management and collaboration."
     }
 ]


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR is to add Open Science events that are occurring externally to SciLifeLab, but of interest to our community. 
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added 2026 events content to: data/open_science/events.json

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
In this file: layouts/shortcodes/update_activities.html
Make sure to uncomment lines 223 and 224 
and then on 228 paste: decodeURIComponent("https%3A%2F%2Fraw.githubusercontent.com%2FScilifelabDataCentre%2Fdata.scilifelab.se%2Frefs%2Fheads%2Fopen_science%2Fdata%2Fopen_science%2Fevents.json"),

Make sure to change these back before pushing. 

 
### ✅ Checklist
- [X] Assignee is selected
- [x] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
