### PR TITLE
FREYA-2056: Updated Thumbnail error for Onboarding of fellows 

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -52,7 +52,7 @@
           <div class="card-teal-25">
             <div {{ if .thumbnail_border }}class="px-1 pt-1" {{ end }}>
               <a target="_self" href="{{ .url }}"><img class="img-fluid"
-                  src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/resource_thumbnails/scilifelab.jpg" }}{{ end }}"
+                  src="{{ with .thumbnail }}{{ . }}{{ else }}{{ "/img/guidance_thumbnails/scilifelab.jpg" }}{{ end }}"
                   alt="{{ .name }}"></a>
             </div>
             <div class="p-2 card-teal-title">


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR contains the fix of thumbnail error for Onboarding of fellows in the guidance section.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Updated the error for standard thumbnail.

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [X] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [X] Jira / Github issue is linked
- [X] Assignee is selected
- [X] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [X] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-2056](https://scilifelab.atlassian.net/browse/FREYA-2056?atlOrigin=eyJpIjoiYTBkZDkyMTlkOGUzNDVkNWI5NTAxNjdkZmY3ZjQxMmMiLCJwIjoiaiJ9)
