### PR TITLE
Freya-2179: create a verification code and add to head

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,6 +5,7 @@
   <title>{{ if ne .Title "SciLifeLab Data Platform"}}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   <meta name="description" content='{{ if .IsHome }}{{ .Param "description" }}{{ else }}{{ .Description }}{{ end }}'>
   <meta http-equiv="content-language" content="en">
+  <meta name="google-site-verification" content="odbEVA-ZoRHXtO34lWnTlb5tOxRRkGciSO4SRIlcqMI" />
 
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
@@ -32,9 +33,6 @@
   <script src="{{ $notice_js.RelPermalink }}" defer></script>
   <!-- JQuery -->
   <script src="https://code.jquery.com/jquery-3.6.3.js" integrity="sha256-nQLuAZGRRcILA+6dMBOvcRh5Pe310sBpanc6+QBmyVM=" crossorigin="anonymous"></script>
-
-  <!-- Google verification tag -->
-  <meta name="google-site-verification" content="odbEVA-ZoRHXtO34lWnTlb5tOxRRkGciSO4SRIlcqMI" />
   
   <!-- imjoy -->
   {{ with .Params.imjoy }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,6 +33,9 @@
   <!-- JQuery -->
   <script src="https://code.jquery.com/jquery-3.6.3.js" integrity="sha256-nQLuAZGRRcILA+6dMBOvcRh5Pe310sBpanc6+QBmyVM=" crossorigin="anonymous"></script>
 
+  <!-- Google verification tag -->
+  <meta name="google-site-verification" content="odbEVA-ZoRHXtO34lWnTlb5tOxRRkGciSO4SRIlcqMI" />
+  
   <!-- imjoy -->
   {{ with .Params.imjoy }}
   <!-- <script src="http://localhost:8080/imjoy-loader.js"></script> -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,7 +33,7 @@
   <script src="{{ $notice_js.RelPermalink }}" defer></script>
   <!-- JQuery -->
   <script src="https://code.jquery.com/jquery-3.6.3.js" integrity="sha256-nQLuAZGRRcILA+6dMBOvcRh5Pe310sBpanc6+QBmyVM=" crossorigin="anonymous"></script>
-  
+
   <!-- imjoy -->
   {{ with .Params.imjoy }}
   <!-- <script src="http://localhost:8080/imjoy-loader.js"></script> -->


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR adds Google verification to the website. The verification is dependent on URL, not on the domain. This means that it would not add any subdomains. Makes use of [these instructions](https://matomo.org/faq/reports/import-google-search-keywords-in-matomo/#how-to-set-up-google-search-console-and-verify-your-website) 
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- added google search verification tag to the head, as outlined in the instructions  

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
Should hopefully work to verify the site. Think that deployment would be needed before we can ask google to verify the site.
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-2179](https://scilifelab.atlassian.net/browse/FREYA-2179)
