### PR TITLE
Update Trivy version

### DIFF
--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         env:
           TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "fs"
           ignore-unfixed: true
@@ -32,7 +32,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-branch

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -10,8 +10,6 @@ name: Trivy - scheduled scan
 
 on:
   workflow_dispatch:
-    branches:
-      - develop
   schedule:
     - cron: '15 8,12 * * *'
 
@@ -32,7 +30,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         env:
           TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'ghcr.io/${{ env.REPOSITORY_OWNER }}/data-scilifelab-se:develop'
           format: 'sarif'


### PR DESCRIPTION
Trivy actions fails saying could not find version `0.28.0`, so changing the version to latest available version at this time.