### PR TITLE
Modify Docker tag configuration

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           images: ${{ matrix.images }}
           tags: |
-            type=sha,prefix={{branch}}-
             type=ref,event=branch
+            type=ref,event=branch,suffix=-{{sha}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
`type=sha,prefix={{branch}}-` is getting trigged for `release` events too, but `release` events don't have `branch` value, thus it ends up being empty and it fails.

So using `type=ref,event=branch,suffix=-{{sha}}` will achieve what we want, without being trigged for `release` events.