### PR TITLE
FREYA-2462: Update pa11y config with chrome executable path

### DIFF
--- a/.github/pa11y.config
+++ b/.github/pa11y.config
@@ -2,8 +2,9 @@
     "defaults": {
         "hideElements": "div.g-recaptcha",
         "chromeLaunchConfig": {
+            "args": ["--disable-dev-shm-usage", "--no-sandbox"],
+            "executablePath": "/usr/bin/google-chrome",
             "ignoreHTTPSErrors": true,
-            "args": ["--disable-dev-shm-usage", "--no-sandbox"]
         }
     }
 }


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR fixes `pa11y-ci` action that fails with `node v24.16`. Something changed between `v24.15` and `v24.16`, thus `pa11y-ci` couldn't find the browser. Specifying the `executionPath` in the config fixes the issue.
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-2462](https://scilifelab.atlassian.net/browse/FREYA-2462)


[FREYA-2462]: https://scilifelab.atlassian.net/browse/FREYA-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ